### PR TITLE
[FIXED JENKINS-25821] - Honor the sensitive variables engine in Mask Passwords

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -39,6 +39,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
+import hudson.util.CopyOnWriteMap;
 import hudson.util.Secret;
 
 import java.io.IOException;
@@ -46,6 +47,8 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.JSONArray;
@@ -136,6 +139,13 @@ public final class MaskPasswordsBuildWrapper extends BuildWrapper {
         }
     }
 
+    @Override
+    public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
+        final Map<String, String> variables = new TreeMap<String, String>();
+        makeBuildVariables(build, variables);    
+        sensitiveVariables.addAll(variables.keySet());
+    }
+    
     @Override
     public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         return new Environment() {

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -73,6 +73,7 @@ public final class MaskPasswordsBuildWrapper extends BuildWrapper {
         this.varPasswordPairs = varPasswordPairs;
     }
 
+    //TODO: Most probably the method is not required after introducing sensitive vars
     /**
      * This method is invoked before {@link #makeBuildVariables()} and {@link
      * #setUp()}.

--- a/src/main/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue.java
@@ -62,6 +62,11 @@ public class PasswordParameterValue extends ParameterValue {
         };
     }
 
+    @Override
+    public final boolean isSensitive() {
+        return true;
+    }
+    
     public String getValue() {
         return value != null ? Secret.toString(value) : null;
     }


### PR DESCRIPTION
This change implements API for sensitive variables, which is required to hide passwords in plugins like EnvInject.

The code is an adjusted copy of <code>makeBuildVariables</code>.

@reviewbybees