### PR TITLE
Mask Regexes and Global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright &copy; 2010-2011, Manufacture Francaise des Pneumatiques Michelin, Rom
 
 About this plugin
 -----------------
-The Mask Passwords plugin is meant to be used from [Hudson][1] or [Jenkins][2] to mask passwords or regulat expressions which may appear from builds' console. Please take a look at [Jenkins' wiki][3] to get detailed information.
+The Mask Passwords plugin is meant to be used from [Hudson][1] or [Jenkins][2] to mask passwords or regular expressions which may appear from builds' console. Please take a look at [Jenkins' wiki][3] to get detailed information.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright &copy; 2010-2011, Manufacture Francaise des Pneumatiques Michelin, Rom
 
 About this plugin
 -----------------
-The Mask Passwords plugin is meant to be used from [Hudson][1] or [Jenkins][2] to mask passwords or regular expressions which may appear from builds' console. Please take a look at [Jenkins' wiki][3] to get detailed information.
+The Mask Passwords plugin is meant to be used from [Jenkins][1] to mask passwords or regular expressions which may appear from builds' console. Please take a look at [Jenkins' wiki][2] to get detailed information.
 
 Installation
 ------------
@@ -12,11 +12,10 @@ The Mask Passwords plugin can be installed from any Hudson or Jenkins installati
 
 Source code
 -----------
-The primary location for the source code of this plugin is on [Jenkins' SVN repository][4]. It is also mirrored on [GitHub][5] for conveniency.
+The primary location for the source code of this plugin is on [Jenkins' SVN repository][3]. It is also mirrored on [GitHub][4] for conveniency.
 
 [0]: https://github.com/jenkinsci/mask-passwords-plugin/raw/master/LICENSE.txt
-[1]: http://hudson-ci.org/
-[2]: http://jenkins-ci.org/
-[3]: http://wiki.jenkins-ci.org/display/JENKINS/Mask+Passwords+Plugin
-[4]: https://svn.jenkins-ci.org/trunk/hudson/plugins/mask-passwords/
-[5]: https://github.com/jenkinsci/mask-passwords-plugin
+[1]: https://jenkins.io/
+[2]: http://wiki.jenkins-ci.org/display/JENKINS/Mask+Passwords+Plugin
+[3]: https://svn.jenkins-ci.org/trunk/hudson/plugins/mask-passwords/
+[4]: https://github.com/jenkinsci/mask-passwords-plugin

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright &copy; 2010-2011, Manufacture Francaise des Pneumatiques Michelin, Rom
 
 About this plugin
 -----------------
-The Mask Passwords plugin is meant to be used from [Hudson][1] or [Jenkins][2] to mask passwords which may appear from builds' console. Please take a look at [Jenkins' wiki][3] to get detailed information.
+The Mask Passwords plugin is meant to be used from [Hudson][1] or [Jenkins][2] to mask passwords or regulat expressions which may appear from builds' console. Please take a look at [Jenkins' wiki][3] to get detailed information.
 
 Installation
 ------------

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import jenkins.tasks.SimpleBuildWrapper;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -77,6 +78,11 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
     public MaskPasswordsBuildWrapper(List<VarPasswordPair> varPasswordPairs, List<VarMaskRegex> varMaskRegexes) {
         this.varPasswordPairs = varPasswordPairs;
         this.varMaskRegexes = varMaskRegexes;
+    }
+
+    public MaskPasswordsBuildWrapper(List<VarPasswordPair> varPasswordPairs) {
+        this.varPasswordPairs = varPasswordPairs;
+        this.varMaskRegexes = new ArrayList<VarMaskRegex>();
     }
 
     @Override
@@ -289,6 +295,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         }
 
         @Override
+        @CheckForNull
         public boolean equals(Object obj) {
             if(obj == null) {
                 return false;

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -381,6 +381,14 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
                     }
                 }
 
+                // global enable
+                if(submittedForm.has("globalVarMaskEnabledGlobally")) {
+                  boolean b = submittedForm.getBoolean("globalVarMaskEnabledGlobally");
+                  if(b) {
+                    getConfig().setGlobalVarEnabledGlobally(true);
+                  }
+                }
+
                 MaskPasswordsConfig.save(getConfig());
 
                 return true;

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -295,7 +295,6 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         }
 
         @Override
-        @CheckForNull
         public boolean equals(Object obj) {
             if(obj == null) {
                 return false;
@@ -310,6 +309,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             return true;
         }
 
+        @CheckForNull
         public String getRegex() {
             return regex;
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -25,6 +25,7 @@
 package com.michelin.cio.hudson.plugins.maskpasswords;
 
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair;
+import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarMaskRegex;
 import hudson.ExtensionList;
 import hudson.XmlFile;
 import hudson.model.Hudson;
@@ -72,13 +73,22 @@ public class MaskPasswordsConfig {
     /**
      * Users can define name/password pairs at the global level to share common
      * passwords with several jobs.
-     * 
+     *
      * <p>Never ever use this attribute directly: Use {@link #getGlobalVarPasswordPairsList} to avoid
      * potential NPEs.</p>
-     * 
+     *
      * @since 2.7
      */
     private List<VarPasswordPair> globalVarPasswordPairs;
+    /**
+     * Users can define regexes at the global level to mask in jobs.
+     *
+     * <p>Never ever use this attribute directly: Use {@link #getGlobalVarPasswordPairsList} to avoid
+     * potential NPEs.</p>
+     *
+     * @since 2.9
+     */
+    private List<VarMaskRegex> globalVarMaskRegexes;
 
     public MaskPasswordsConfig() {
         maskPasswordsParamDefClasses = new LinkedHashSet<String>();
@@ -90,10 +100,10 @@ public class MaskPasswordsConfig {
 
     /**
      * Adds a name/password pair at the global level.
-     * 
+     *
      * <p>If either name or password is blank (as defined per the Commons Lang
      * library), then the pair is not added.</p>
-     * 
+     *
      * @since 2.7
      */
     public void addGlobalVarPasswordPair(VarPasswordPair varPasswordPair) {
@@ -102,6 +112,22 @@ public class MaskPasswordsConfig {
             return;
         }
         getGlobalVarPasswordPairsList().add(varPasswordPair);
+    }
+
+    /**
+     * Adds a regex at the global level.
+     *
+     * <p>If regex is blank (as defined per the Commons Lang
+     * library), then the pair is not added.</p>
+     *
+     * @since 2.9
+     */
+    public void addGlobalVarMaskRegex(VarMaskRegex varMaskRegex) {
+        // blank values are forbidden
+        if(StringUtils.isBlank(varMaskRegex.getRegex())) {
+            return;
+        }
+        getGlobalVarMaskRegexesList().add(varMaskRegex);
     }
 
     /**
@@ -116,6 +142,7 @@ public class MaskPasswordsConfig {
     public void clear() {
         maskPasswordsParamDefClasses.clear();
         getGlobalVarPasswordPairsList().clear();
+        getGlobalVarMaskRegexesList().clear();
     }
 
     public static MaskPasswordsConfig getInstance() {
@@ -131,21 +158,41 @@ public class MaskPasswordsConfig {
 
     /**
      * Returns the list of name/password pairs defined at the global level.
-     * 
+     *
      * <p>Modifications broughts to the returned list has no impact on this
      * configuration (the returned value is a copy). Also, the list can be
      * empty but never {@code null}.</p>
-     * 
+     *
      * @since 2.7
      */
     public List<VarPasswordPair> getGlobalVarPasswordPairs() {
         List<VarPasswordPair> r = new ArrayList<VarPasswordPair>(getGlobalVarPasswordPairsList().size());
-        
+
         // deep copy
         for(VarPasswordPair varPasswordPair: getGlobalVarPasswordPairsList()) {
             r.add((VarPasswordPair) varPasswordPair.clone());
         }
-        
+
+        return r;
+    }
+
+    /**
+     * Returns the list of regexes defined at the global level.
+     *
+     * <p>Modifications broughts to the returned list has no impact on this
+     * configuration (the returned value is a copy). Also, the list can be
+     * empty but never {@code null}.</p>
+     *
+     * @since 2.9
+     */
+    public List<VarMaskRegex> getGlobalVarMaskRegexes() {
+        List<VarMaskRegex> r = new ArrayList<VarMaskRegex>(getGlobalVarMaskRegexesList().size());
+
+        // deep copy
+        for(VarMaskRegex varMaskRegex: getGlobalVarMaskRegexesList()) {
+            r.add((VarMaskRegex) varMaskRegex.clone());
+        }
+
         return r;
     }
 
@@ -153,7 +200,7 @@ public class MaskPasswordsConfig {
      * Fixes JENKINS-11514: When {@code MaskPasswordsConfig.xml} is there but was created from
      * version 2.6.1 (or older) of the plugin, {@link #globalVarPasswordPairs} can actually be
      * {@code null} ==> Always use this getter to avoid NPEs.
-     * 
+     *
      * @since 2.7.1
      */
     private List<VarPasswordPair> getGlobalVarPasswordPairsList() {
@@ -161,6 +208,20 @@ public class MaskPasswordsConfig {
             globalVarPasswordPairs = new ArrayList<VarPasswordPair>();
         }
         return globalVarPasswordPairs;
+    }
+
+    /**
+     * Fixes JENKINS-11514: When {@code MaskPasswordsConfig.xml} is there but was created from
+     * version 2.8 (or older) of the plugin, {@link #globalVarPasswordPairs} can actually be
+     * {@code null} ==> Always use this getter to avoid NPEs.
+     *
+     * @since 2.9
+     */
+    private List<VarMaskRegex> getGlobalVarMaskRegexesList() {
+        if(globalVarMaskRegexes == null) {
+            globalVarMaskRegexes = new ArrayList<VarMaskRegex>();
+        }
+        return globalVarMaskRegexes;
     }
 
     /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -83,7 +83,7 @@ public class MaskPasswordsConfig {
     /**
      * Users can define regexes at the global level to mask in jobs.
      *
-     * <p>Never ever use this attribute directly: Use {@link #getGlobalVarPasswordPairsList} to avoid
+     * <p>Never ever use this attribute directly: Use {@link #getGlobalVarMaskRegexes} to avoid
      * potential NPEs.</p>
      *
      * @since 2.9
@@ -116,6 +116,7 @@ public class MaskPasswordsConfig {
     public void addGlobalVarPasswordPair(VarPasswordPair varPasswordPair) {
         // blank values are forbidden
         if(StringUtils.isBlank(varPasswordPair.getVar()) || StringUtils.isBlank(varPasswordPair.getPassword())) {
+            LOGGER.fine("addGlobalVarPasswordPair NOT adding pair with null var or password");
             return;
         }
         getGlobalVarPasswordPairsList().add(varPasswordPair);
@@ -132,6 +133,7 @@ public class MaskPasswordsConfig {
     public void addGlobalVarMaskRegex(VarMaskRegex varMaskRegex) {
         // blank values are forbidden
         if(StringUtils.isBlank(varMaskRegex.getRegex())) {
+            LOGGER.fine("addGlobalVarMaskRegex NOT adding null regex");
             return;
         }
         getGlobalVarMaskRegexesList().add(varMaskRegex);

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -89,6 +89,12 @@ public class MaskPasswordsConfig {
      * @since 2.9
      */
     private List<VarMaskRegex> globalVarMaskRegexes;
+    /**
+     * Whether or not to enable the plugin globally on ALL BUILDS.
+     *
+     * @since 2.9
+     */
+    private boolean globalVarEnableGlobally;
 
     public MaskPasswordsConfig() {
         maskPasswordsParamDefClasses = new LinkedHashSet<String>();
@@ -96,6 +102,7 @@ public class MaskPasswordsConfig {
         // default values for the first time the config is created
         addMaskedPasswordParameterDefinition(hudson.model.PasswordParameterDefinition.class.getName());
         addMaskedPasswordParameterDefinition(com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition.class.getName());
+        globalVarEnableGlobally = false;
     }
 
     /**
@@ -139,10 +146,15 @@ public class MaskPasswordsConfig {
         maskPasswordsParamDefClasses.add(className);
     }
 
+    public void setGlobalVarEnabledGlobally(boolean state) {
+      globalVarEnableGlobally = state;
+    }
+
     public void clear() {
         maskPasswordsParamDefClasses.clear();
         getGlobalVarPasswordPairsList().clear();
         getGlobalVarMaskRegexesList().clear();
+        globalVarEnableGlobally = false;
     }
 
     public static MaskPasswordsConfig getInstance() {
@@ -246,6 +258,13 @@ public class MaskPasswordsConfig {
     }
 
     /**
+     * Returns whether the plugin is enabled globally for ALL BUILDS.
+     */
+    public boolean isEnabledGlobally() {
+      return globalVarEnableGlobally;
+    }
+
+    /**
      * Returns true if the specified parameter value class name corresponds to
      * a parameter definition class name selected in Hudson's/Jenkins' main
      * configuration screen.
@@ -320,7 +339,7 @@ public class MaskPasswordsConfig {
         catch(Exception e) {
             LOGGER.log(Level.WARNING, "Unable to load Mask Passwords plugin configuration from " + CONFIG_FILE, e);
         }
-
+        LOGGER.log(Level.FINE, "No Mask Passwords config file loaded; using defaults");
         return new MaskPasswordsConfig();
     }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010-2012, Manufacture Francaise des Pneumatiques Michelin,
- * Romain Seguy
+ * Copyright (c) 2016 Cox Automotive, Inc./Manheim, Jason Antman.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -67,7 +66,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * GLOBAL Console Log Filter that alters the console so that passwords don't
  * get displayed.
  *
- * @author Jason Antman <jason@jasonantman.com>
+ * @author Jason Antman jason@jasonantman.com
  */
 @Extension
 public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter {

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010-2012, Manufacture Francaise des Pneumatiques Michelin,
+ * Romain Seguy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.michelin.cio.hudson.plugins.maskpasswords;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.console.ConsoleLogFilter;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildWrapperDescriptor;
+import hudson.util.Secret;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.tasks.SimpleBuildWrapper;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jvnet.localizer.Localizable;
+import org.jvnet.localizer.ResourceBundleHolder;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * GLOBAL Console Log Filter that alters the console so that passwords don't
+ * get displayed.
+ *
+ * @author Jason Antman <jason@jasonantman.com>
+ */
+@Extension
+public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter {
+
+  public MaskPasswordsConsoleLogFilter() {
+    // nothing to do here; this object lives for the lifetime of Jenkins,
+    // so if we don't want to have to restart to detect config changes,
+    // we need to get the config in each run.
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public OutputStream decorateLogger(AbstractBuild _ignore, OutputStream logger) throws IOException, InterruptedException {
+      // check the config
+      MaskPasswordsConfig config = MaskPasswordsConfig.getInstance();
+      if(! config.isEnabledGlobally()) {
+        LOGGER.log(Level.FINE, "MaskPasswords not enabled globally; not decorating logger");
+        return logger;
+      }
+      LOGGER.log(Level.FINE, "MaskPasswords IS enabled globally; decorating logger");
+
+      // build our config
+      List<String> passwords = new ArrayList<String>();
+      List<String> regexes = new ArrayList<String>();
+
+      // global passwords
+      List<MaskPasswordsBuildWrapper.VarPasswordPair> globalVarPasswordPairs = config.getGlobalVarPasswordPairs();
+      for(MaskPasswordsBuildWrapper.VarPasswordPair globalVarPasswordPair: globalVarPasswordPairs) {
+          passwords.add(globalVarPasswordPair.getPassword());
+      }
+
+      // global regexes
+      List<MaskPasswordsBuildWrapper.VarMaskRegex> globalVarMaskRegexes = config.getGlobalVarMaskRegexes();
+      for(MaskPasswordsBuildWrapper.VarMaskRegex globalVarMaskRegex: globalVarMaskRegexes) {
+          regexes.add(globalVarMaskRegex.getRegex());
+      }
+      return new MaskPasswordsOutputStream(logger, passwords, regexes);
+  }
+
+  private static final Logger LOGGER = Logger.getLogger(MaskPasswordsConsoleLogFilter.class.getName());
+
+}

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
@@ -52,25 +52,33 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
     public MaskPasswordsOutputStream(OutputStream logger, Collection<String> passwords, Collection<String> regexes) {
         this.logger = logger;
 
-        /**
-         * WIP - untested, but I believe I have all of the regex support done except for this, actually
-         * adding the regexes to the master masking regex. I need to give some thought to the cleanest
-         * way to implement this.
-         */
-        if(passwords != null && passwords.size() > 0) {
+
+        if((passwords != null && passwords.size() > 0) || (regexes != null && regexes.size() > 0)) {
             // passwords are aggregated into a regex which is compiled as a pattern
             // for efficiency
             StringBuilder regex = new StringBuilder().append('(');
-            // JANTMAN regex.append("plain2text2|");
 
             int nbMaskedPasswords = 0;
-            for(String password: passwords) {
-                if(StringUtils.isNotEmpty(password)) { // we must not handle empty passwords
-                    regex.append(Pattern.quote(password));
-                    regex.append('|');
-                    nbMaskedPasswords++;
-                }
+
+            if(passwords != null && passwords.size() > 0) {
+              for(String password: passwords) {
+                  if(StringUtils.isNotEmpty(password)) { // we must not handle empty passwords
+                      regex.append(Pattern.quote(password));
+                      regex.append('|');
+                      nbMaskedPasswords++;
+                  }
+              }
             }
+            if(regexes != null && regexes.size() > 0) {
+              for(String user_regex: regexes) {
+                  if(StringUtils.isNotEmpty(user_regex)) { // we must not handle empty passwords
+                      regex.append(user_regex);
+                      regex.append('|');
+                      nbMaskedPasswords++;
+                  }
+              }
+            }
+
             if(nbMaskedPasswords++ >= 1) { // is there at least one password to mask?
                 regex.deleteCharAt(regex.length()-1); // removes the last unuseful pipe
                 regex.append(')');

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
@@ -49,13 +49,19 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
      *               will write to
      * @param passwords A collection of {@link String}s to be masked
      */
-    public MaskPasswordsOutputStream(OutputStream logger, Collection<String> passwords) {
+    public MaskPasswordsOutputStream(OutputStream logger, Collection<String> passwords, Collection<String> regexes) {
         this.logger = logger;
 
+        /**
+         * WIP - untested, but I believe I have all of the regex support done except for this, actually
+         * adding the regexes to the master masking regex. I need to give some thought to the cleanest
+         * way to implement this.
+         */
         if(passwords != null && passwords.size() > 0) {
             // passwords are aggregated into a regex which is compiled as a pattern
             // for efficiency
             StringBuilder regex = new StringBuilder().append('(');
+            // JANTMAN regex.append("plain2text2|");
 
             int nbMaskedPasswords = 0;
             for(String password: passwords) {

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.regex.Pattern;
+import javax.annotation.CheckForNull;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -48,8 +49,9 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
      * @param logger The output stream to which this {@link MaskPasswordsOutputStream}
      *               will write to
      * @param passwords A collection of {@link String}s to be masked
+     * @param regexes A collection of Regular Expression {@link String}s to be masked
      */
-    public MaskPasswordsOutputStream(OutputStream logger, Collection<String> passwords, Collection<String> regexes) {
+    public MaskPasswordsOutputStream(OutputStream logger, @CheckForNull Collection<String> passwords, @CheckForNull Collection<String> regexes) {
         this.logger = logger;
 
 
@@ -91,6 +93,15 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
         else { // no passwords to hide
             passwordsAsPattern = null;
         }
+    }
+
+    /**
+     * @param logger The output stream to which this {@link MaskPasswordsOutputStream}
+     *               will write to
+     * @param passwords A collection of {@link String}s to be masked
+     */
+    public MaskPasswordsOutputStream(OutputStream logger, @CheckForNull Collection<String> passwords) {
+        this(logger, passwords, null);
     }
 
     @Override

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.properties
@@ -21,4 +21,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-DisplayName=Mask passwords (and enable global passwords)
+DisplayName=Mask passwords and regexes (and enable global passwords)

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
@@ -50,4 +50,18 @@
             </table>
         </f:repeatable>
     </f:entry>
+    <!-- regexes -->
+    <f:entry field="varMaskRegexes">
+        <f:repeatable name="varMaskRegexes" items="${instance.varMaskRegexes}" var="varMaskRegex">
+            <table width="100%">
+                <tr>
+                    <td width="10%" align="right">${%Regex}</td>
+                    <td width="70%">
+                        <f:textbox name="varMaskRegex.regex" value="${!empty varMaskRegex.regex?varMaskRegex.regex:''}"/>
+                    </td>
+                    <td width="20%" align="right"><f:repeatableDeleteButton/></td>
+                </tr>
+            </table>
+        </f:repeatable>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
@@ -33,6 +33,11 @@
         </td>
         <td/>
     </tr>
+    <tr>
+        <td/>
+        <td colspan="2">${%PasswordPairTitle}</td>
+        <td/>
+    </tr>
     <f:entry field="varPasswordPairs">
         <f:repeatable name="varPasswordPairs" items="${instance.varPasswordPairs}" var="varPasswordPair">
             <table width="100%">
@@ -51,6 +56,11 @@
         </f:repeatable>
     </f:entry>
     <!-- regexes -->
+    <tr>
+        <td/>
+        <td colspan="2">${%RegexTitle}</td>
+        <td/>
+    </tr>
     <f:entry field="varMaskRegexes">
         <f:repeatable name="varMaskRegexes" items="${instance.varMaskRegexes}" var="varMaskRegex">
             <table width="100%">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
@@ -24,3 +24,5 @@ HowToConfigureThisPlugin=<strong>Password Parameter</strong>s, or any other \
     type of build parameters or regexes selected for masking in Hudson''s/Jenkins'' main \
     configuration screen (<strong>Manage Hudson</strong> > <strong>Configure \
     System</strong>), will be automatically masked.
+PasswordPairTitle=Name/Password Pairs
+RegexTitle=Regular Expressions

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
@@ -21,6 +21,6 @@
 # THE SOFTWARE.
 
 HowToConfigureThisPlugin=<strong>Password Parameter</strong>s, or any other \
-    type of build parameters selected for masking in Hudson''s/Jenkins'' main \
+    type of build parameters or regexes selected for masking in Hudson''s/Jenkins'' main \
     configuration screen (<strong>Manage Hudson</strong> > <strong>Configure \
     System</strong>), will be automatically masked.

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
@@ -53,4 +53,20 @@
             </f:repeatable>
         </f:entry>
     </f:section>
+    <!-- global regexes -->
+    <f:section title="${%GlobalVarMaskRegexes}">
+        <f:entry field="globalVarMaskRegexes">
+            <f:repeatable name="globalVarMaskRegexes" items="${descriptor.config.globalVarMaskRegexes}" var="globalVarMaskRegex">
+                <table width="100%">
+                    <tr>
+                        <td width="10%" align="right">${%Regex}</td>
+                        <td width="70%">
+                            <f:textbox name="globalVarMaskRegex.regex" value="${!empty globalVarMaskRegex.regex?globalVarMaskRegex.regex:''}"/>
+                        </td>
+                        <td width="20%" align="right"><f:repeatableDeleteButton/></td>
+                    </tr>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
@@ -26,7 +26,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <!-- global enable -->
     <f:section title="${%EnabledGlobally}">
-      <f:entry title="${%Enable Mask Passwords for ALL BUILDS}" description="${%High possibility of breaking things; use this only as a last resort and read help}" field="globalVarMaskEnabledGlobally">
+      <f:entry title="${%Enable Mask Passwords for ALL BUILDS}" description="${%High possibility of breaking things; use this only as a last resort. Read help before enabling!}" field="globalVarMaskEnabledGlobally">
           <f:checkbox checked="${descriptor.config.isEnabledGlobally()}" />
       </f:entry>
     </f:section>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
@@ -24,6 +24,12 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <!-- global enable -->
+    <f:section title="${%EnabledGlobally}">
+      <f:entry title="${%Enable Mask Passwords for ALL BUILDS}" description="${%High possibility of breaking things; use this only as a last resort and read help}" field="globalVarMaskEnabledGlobally">
+          <f:checkbox checked="${descriptor.config.isEnabledGlobally()}" />
+      </f:entry>
+    </f:section>
     <!-- parameter definitions to be automatically masked -->
     <f:section title="${%ParameterDefinitions}">
         <j:forEach var="paramDef" items="${descriptor.config.parameterDefinitions}">

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
@@ -24,3 +24,4 @@ GlobalVarPasswordPairs=Mask Passwords - Global name/password pairs
 ParameterDefinitions=Mask Passwords - Parameters to automatically mask
 GlobalVarMaskRegexes=Mask Passwords - Global Regexes
 Regex=Regex to automatically mask
+EnabledGlobally=Mask Passwords - Enable Globally

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
@@ -23,4 +23,4 @@
 GlobalVarPasswordPairs=Mask Passwords - Global name/password pairs
 ParameterDefinitions=Mask Passwords - Parameters to automatically mask
 GlobalVarMaskRegexes=Mask Passwords - Global Regexes
-Regex=Mask Passwords - Regex to automatically mask
+Regex=Regex to automatically mask

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.properties
@@ -22,3 +22,5 @@
 
 GlobalVarPasswordPairs=Mask Passwords - Global name/password pairs
 ParameterDefinitions=Mask Passwords - Parameters to automatically mask
+GlobalVarMaskRegexes=Mask Passwords - Global Regexes
+Regex=Mask Passwords - Regex to automatically mask

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
@@ -1,5 +1,7 @@
 <div>
-    If checked, the MaskPasswordsBuildWrapper will be injected into EVERY Build that does not have it already configured on the Job.
-    Builds of anything not derived from hudson.models.Job will fail. Other problems may be encountered. Use this only if you'd rather have
-    <span style="color:red">builds fail in strange ways</span> than possibly disclose a secret in build output!
+    If checked, the a MaskPasswordsConsoleLogFilter will be injected into EVERY Build, regardless of the Project's settings.
+    This is generally bad practice, but if your foremost concern is having secrets hidden, it may be worth trying. Note that
+    this should be tested with your jobs before being relied on; it's possible that custom Job types will not honor this.
+    Workflow jobs in Jenkins versions before 1.632 will not honor this
+    (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-30777">JENKINS-30777</a>).
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
@@ -1,0 +1,5 @@
+<div>
+    If checked, the MaskPasswordsBuildWrapper will be injected into EVERY Build that does not have it already configured on the Job.
+    Builds of anything not derived from hudson.models.Job will fail. Other problems may be encountered. Use this only if you'd rather have
+    <span style="color:red">builds fail in strange ways</span> than possibly disclose a secret in build output!
+</div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskRegexes.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskRegexes.html
@@ -23,9 +23,15 @@
   -->
 
 <div>
-    <p>Define a list of <b>Name</b>/<b>Password</b> pairs to be used from jobs
-    as build variables. If the <b>Mask passwords</b> option is enabled on these
+    <p>Define a list of regular expression patterns
+    to be masked in build output. If the <b>Mask passwords</b> option is enabled on these
     jobs or the <b>Mask Passwords - Enable Globally</b> global option is enabled,
-    then the defined passwords will be automatically masked from the console.</p>
-    <p>Blank values are not accepted (for both name and password).</p>
+    then the defined regexes will be automatically masked from the console.</p>
+    <p>Blank values are not accepted. Patterns will be compiled via
+    <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>.
+    Regexes and patterns for defined passwords will be combined with pipes ("|")
+    within one large parenthesized pattern to mask from output (i.e. the final pattern to mask
+    for two passwords ("Password1" and "Password2") and two regexes ("Regex1" and "Regex2")
+    will be: "(Password1|Password2|Regex1|Regex2)").
+    </p>
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarPasswordPairs.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarPasswordPairs.html
@@ -23,9 +23,9 @@
   -->
 
 <div>
-    <p>Define a list of <b>Name</b>/<b>Password</b> pairs to be used from jobs
+    <p>Define a list of <b>Name</b>/<b>Password</b> pairs or regexes to be used from jobs
     as build variables. If the <b>Mask passwords</b> option is enabled on these
-    jobs, then the defined passwords will be automatically masked from the
+    jobs, then the defined passwords and regexes will be automatically masked from the
     console.</p>
     <p>Blank values are not accepted (for both name and password).</p>
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help.html
@@ -25,16 +25,16 @@
 
 <div>
     <p>When enabled, allows masking passwords that may appear in the console.</p>
-    <p>Passwords to be masked can be defined at three levels.</p>
+    <p>Passwords or regexes to be masked can be defined at three levels.</p>
     <p>First, it is possible to select in Hudson's/Jenkins' configuration screen
     the build parameters whose value must be masked. For example, selecting the
     <b>Password Parameter</b> type is a good idea.</p>
     <p>Second, still in Hudson's/Jenkins' configuration screen, it is possible
     to define passwords to be masked as global <b>Name</b>/<b>Password</b>
-    pairs.</p>
+    pairs, or regexes to be masked.</p>
     <p>Third, on a per job basis (that is, in the current configuration screen),
     passwords to be masked can be defined as local <b>Name</b>/<b>Password</b>
-    pairs:<ul>
+    pairs, or regexes can be masked:<ul>
     <li><b>Password</b> is aimed at containing a password to be masked from the
     console. Empty and blank values are not allowed (e.g. &quot;&nbsp;&quot;,
     etc.). This field is ciphered. This field can not contain variables, they
@@ -43,5 +43,9 @@
     This allows accessing the password by using the variable rather than hard-coding
     it in a field which is not ciphered (e.g. the ones of the <b>Invoke Ant</b> or
     <b>Execute shell</b> build steps).</li>
+    <li>If <b>Regex</b> is set, then any text matching that regex will be masked
+    in the console output. The regex should not contain start- or end-of-string
+    markers and will be internally and-ed (piped) together with all other regexes
+    and regexes matching the specified names and passwords.</li>
     </ul>
 </div>

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -61,15 +61,22 @@ public class MaskPasswordsWorkflowTest {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                MaskPasswordsBuildWrapper bw1 = new MaskPasswordsBuildWrapper(Collections.singletonList(new MaskPasswordsBuildWrapper.VarPasswordPair("PASSWORD", "s3cr3t")));
+                MaskPasswordsBuildWrapper bw1 = new MaskPasswordsBuildWrapper(
+                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarPasswordPair("PASSWORD", "s3cr3t")),
+                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarMaskRegex("foobar"))
+                );
                 CoreWrapperStep step1 = new CoreWrapperStep(bw1);
                 CoreWrapperStep step2 = new StepConfigTester(story.j).configRoundTrip(step1);
                 MaskPasswordsBuildWrapper bw2 = (MaskPasswordsBuildWrapper) step2.getDelegate();
                 List<MaskPasswordsBuildWrapper.VarPasswordPair> pairs = bw2.getVarPasswordPairs();
+                List<MaskPasswordsBuildWrapper.VarMaskRegex> regexes = bw2.getVarMaskRegexes();
                 assertEquals(1, pairs.size());
+                assertEquals(1, regexes.size());
                 MaskPasswordsBuildWrapper.VarPasswordPair pair = pairs.get(0);
                 assertEquals("PASSWORD", pair.getVar());
                 assertEquals("s3cr3t", pair.getPassword());
+                MaskPasswordsBuildWrapper.VarMaskRegex regex = regexes.get(0);
+                assertEquals("foobar", regex.getRegex());
             }
         });
     }

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -70,19 +70,34 @@ public class MaskPasswordsWorkflowTest {
             @Override
             public void evaluate() throws Throwable {
                 MaskPasswordsBuildWrapper bw1 = new MaskPasswordsBuildWrapper(
-                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarPasswordPair("PASSWORD", "s3cr3t")),
-                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarMaskRegex("foobar"))
+                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarPasswordPair("PASSWORD", "s3cr3t"))
                 );
                 CoreWrapperStep step1 = new CoreWrapperStep(bw1);
                 CoreWrapperStep step2 = new StepConfigTester(story.j).configRoundTrip(step1);
                 MaskPasswordsBuildWrapper bw2 = (MaskPasswordsBuildWrapper) step2.getDelegate();
                 List<MaskPasswordsBuildWrapper.VarPasswordPair> pairs = bw2.getVarPasswordPairs();
-                List<MaskPasswordsBuildWrapper.VarMaskRegex> regexes = bw2.getVarMaskRegexes();
                 assertEquals(1, pairs.size());
-                assertEquals(1, regexes.size());
                 MaskPasswordsBuildWrapper.VarPasswordPair pair = pairs.get(0);
                 assertEquals("PASSWORD", pair.getVar());
                 assertEquals("s3cr3t", pair.getPassword());
+            }
+        });
+    }
+
+    @Test
+    public void regexConfigRoundTrip() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MaskPasswordsBuildWrapper bw1 = new MaskPasswordsBuildWrapper(
+                  null,
+                  Collections.singletonList(new MaskPasswordsBuildWrapper.VarMaskRegex("foobar"))
+                );
+                CoreWrapperStep step1 = new CoreWrapperStep(bw1);
+                CoreWrapperStep step2 = new StepConfigTester(story.j).configRoundTrip(step1);
+                MaskPasswordsBuildWrapper bw2 = (MaskPasswordsBuildWrapper) step2.getDelegate();
+                List<MaskPasswordsBuildWrapper.VarMaskRegex> regexes = bw2.getVarMaskRegexes();
+                assertEquals(1, regexes.size());
                 MaskPasswordsBuildWrapper.VarMaskRegex regex = regexes.get(0);
                 assertEquals("foobar", regex.getRegex());
             }

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -106,6 +106,61 @@ public class MaskPasswordsWorkflowTest {
         });
     }
 
+    @Test
+    public void notEnabledGlobally() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MaskPasswordsConfig config = MaskPasswordsConfig.getInstance();
+                config.setGlobalVarEnabledGlobally(false);
+                MaskPasswordsConfig.save(config);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+                p.setDefinition(new CpsFlowDefinition("node {semaphore 'restarting'; echo 'printed s3cr3t oops'}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("restarting/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p2", WorkflowJob.class);
+                WorkflowRun b = p.getLastBuild();
+                assertEquals("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better", new HashSet<String>(Arrays.asList("build.xml", "program.dat")), grep(b.getRootDir(), "s3cr3t"));
+                SemaphoreStep.success("restarting/1", null);
+                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+                story.j.assertLogContains("printed s3cr3t oops", b);
+            }
+        });
+    }
+
+    @Test
+    public void enabledGlobally() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MaskPasswordsConfig config = MaskPasswordsConfig.getInstance();
+                config.setGlobalVarEnabledGlobally(true);
+                config.addGlobalVarMaskRegex(new MaskPasswordsBuildWrapper.VarMaskRegex("s\\dcr[0-9]t"));
+                MaskPasswordsConfig.save(config);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p2");
+                p.setDefinition(new CpsFlowDefinition("node {semaphore 'restarting'; echo 'printed s3cr3t oops'}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("restarting/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p2", WorkflowJob.class);
+                WorkflowRun b = p.getLastBuild();
+                assertEquals("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better", new HashSet<String>(Arrays.asList("build.xml", "program.dat")), grep(b.getRootDir(), "s3cr3t"));
+                SemaphoreStep.success("restarting/1", null);
+                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(b));
+                story.j.assertLogContains("printed ******** oops", b);
+            }
+        });
+    }
+
     // Copied from credentials-binding-plugin; perhaps belongs in JenkinsRule?
     private static Set<String> grep(File dir, String text) throws IOException {
         Set<String> matches = new TreeSet<String>();


### PR DESCRIPTION
This pull request adds two major features to the Mask Passwords plugin:
1. The ability to mask user-defined regular expressions in addition to passwords. This is useful because (a) it doesn't require defining the password explicitly in the configuration and, (b) it supports masking secrets that aren't known ahead of time. Our use case is AWS credentials; the AWS secret key portion of credentials [matches](https://blogs.aws.amazon.com/security/post/Tx1XG3FX6VMU6O5/A-safer-way-to-distribute-AWS-credentials-to-EC2) `(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])`. The previous Mask Passwords implementation caused problems for jobs that use temporary credentials, or that generate their own credentials and echo them in the job's output.
2. The ability to enable the plugin globally. This is implented as a ConsoleLogFilter not inside a BuildWrapper, i.e. a global ConsoleLogFilter. The implementation checks the plugin's global configuration, and only decorates the logger if the global enable setting is true. I'm aware that this is probably a **bad** thing for most users, and have done my best to make the help messages very clear for that. However, for some users (such as myself) who don't have centralized control over job configuration (i.e. anyone in the organization can add or modify jobs), this is necessary in order to suppress credentials from being logged.

I've tested this manually to the best of my abilities using both Jenkins 1.609.1 (as set in `pom.xml`) as well as the official Docker images of 1.625.2 and 2.7.1.
