### PR TITLE
Invoke flush() and close() for the logger in MaskPasswordOutputStream

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsOutputStream.java
@@ -88,4 +88,23 @@ public class MaskPasswordsOutputStream extends LineTransformationOutputStream {
         logger.write(line.getBytes());
     }
 
+    /**
+     * {@inheritDoc}
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException {
+        super.close();
+        logger.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws IOException
+     */
+    @Override
+    public void flush() throws IOException {
+        super.flush();
+        logger.flush();
+    }
 }


### PR DESCRIPTION
the logger maybe buffered output stream (other plugin implemented ConsoleLogFilter may add another layer of buffer), need allow caller to flush and close the logger