### PR TITLE
[JENKINS-25735] Credentials can now be masked

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -65,7 +65,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Build wrapper that alters the console so that passwords don't get displayed.
- *
+ * 
  * @author Romain Seguy (http://openromain.blogspot.com)
  */
 public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
@@ -169,10 +169,10 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
     @Override
     public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
         final Map<String, String> variables = new TreeMap<String, String>();
-        makeBuildVariables(build, variables);
+        makeBuildVariables(build, variables);    
         sensitiveVariables.addAll(variables.keySet());
     }
-
+    
     @Override
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         // nothing to do here
@@ -241,7 +241,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
 
     @Extension(ordinal = 1000) // JENKINS-12161
     public static final class DescriptorImpl extends BuildWrapperDescriptor {
-
+        
         public DescriptorImpl() {
             super(MaskPasswordsBuildWrapper.class);
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -65,7 +65,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Build wrapper that alters the console so that passwords don't get displayed.
- * 
+ *
  * @author Romain Seguy (http://openromain.blogspot.com)
  */
 public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
@@ -169,10 +169,10 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
     @Override
     public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {
         final Map<String, String> variables = new TreeMap<String, String>();
-        makeBuildVariables(build, variables);    
+        makeBuildVariables(build, variables);
         sensitiveVariables.addAll(variables.keySet());
     }
-    
+
     @Override
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         // nothing to do here
@@ -241,7 +241,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
 
     @Extension(ordinal = 1000) // JENKINS-12161
     public static final class DescriptorImpl extends BuildWrapperDescriptor {
-        
+
         public DescriptorImpl() {
             super(MaskPasswordsBuildWrapper.class);
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -72,10 +72,10 @@ public class MaskPasswordsConfig {
     /**
      * Users can define name/password pairs at the global level to share common
      * passwords with several jobs.
-     * 
+     *
      * <p>Never ever use this attribute directly: Use {@link #getGlobalVarPasswordPairsList} to avoid
      * potential NPEs.</p>
-     * 
+     *
      * @since 2.7
      */
     private List<VarPasswordPair> globalVarPasswordPairs;
@@ -90,10 +90,10 @@ public class MaskPasswordsConfig {
 
     /**
      * Adds a name/password pair at the global level.
-     * 
+     *
      * <p>If either name or password is blank (as defined per the Commons Lang
      * library), then the pair is not added.</p>
-     * 
+     *
      * @since 2.7
      */
     public void addGlobalVarPasswordPair(VarPasswordPair varPasswordPair) {
@@ -131,21 +131,21 @@ public class MaskPasswordsConfig {
 
     /**
      * Returns the list of name/password pairs defined at the global level.
-     * 
+     *
      * <p>Modifications broughts to the returned list has no impact on this
      * configuration (the returned value is a copy). Also, the list can be
      * empty but never {@code null}.</p>
-     * 
+     *
      * @since 2.7
      */
     public List<VarPasswordPair> getGlobalVarPasswordPairs() {
         List<VarPasswordPair> r = new ArrayList<VarPasswordPair>(getGlobalVarPasswordPairsList().size());
-        
+
         // deep copy
         for(VarPasswordPair varPasswordPair: getGlobalVarPasswordPairsList()) {
             r.add((VarPasswordPair) varPasswordPair.clone());
         }
-        
+
         return r;
     }
 
@@ -153,7 +153,7 @@ public class MaskPasswordsConfig {
      * Fixes JENKINS-11514: When {@code MaskPasswordsConfig.xml} is there but was created from
      * version 2.6.1 (or older) of the plugin, {@link #globalVarPasswordPairs} can actually be
      * {@code null} ==> Always use this getter to avoid NPEs.
-     * 
+     *
      * @since 2.7.1
      */
     private List<VarPasswordPair> getGlobalVarPasswordPairsList() {
@@ -226,8 +226,9 @@ public class MaskPasswordsConfig {
                         }
                     }};
 
-                    for(Method m: methods) {
-                        maskPasswordsParamValueClasses.add(m.getReturnType().getName());
+                    //If this parameter actions respinds to any of these. Lets add it.
+                    if(!methods.isEmpty()) {
+                        maskPasswordsParamValueClasses.add(paramValueClassName);
                     }
                 }
             }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -189,7 +189,7 @@ public class MaskPasswordsConfig {
      * a parameter definition class name selected in Hudson's/Jenkins' main
      * configuration screen.
      */
-    public boolean isMasked(String paramValueClassName) {
+    public synchronized boolean isMasked(String paramValueClassName) {
         try {
             // do we need to build the set of parameter values which must be
             // masked?

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -314,7 +314,9 @@ public class MaskPasswordsConfig {
                         }
                     }};
 
-                    //If this parameter actions respinds to any of these. Lets add it.
+                    // If the class defines any method, we consider it as a ParameterDefinition.
+                    // This parameter definition may produce any ParameterValue, and effectively we cannot guarantee the 
+                    // value is a type or a subtype of the requested parameter.
                     if(!methods.isEmpty()) {
                         maskPasswordsParamValueClasses.add(paramValueClassName);
                     }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -72,10 +72,10 @@ public class MaskPasswordsConfig {
     /**
      * Users can define name/password pairs at the global level to share common
      * passwords with several jobs.
-     *
+     * 
      * <p>Never ever use this attribute directly: Use {@link #getGlobalVarPasswordPairsList} to avoid
      * potential NPEs.</p>
-     *
+     * 
      * @since 2.7
      */
     private List<VarPasswordPair> globalVarPasswordPairs;
@@ -90,10 +90,10 @@ public class MaskPasswordsConfig {
 
     /**
      * Adds a name/password pair at the global level.
-     *
+     * 
      * <p>If either name or password is blank (as defined per the Commons Lang
      * library), then the pair is not added.</p>
-     *
+     * 
      * @since 2.7
      */
     public void addGlobalVarPasswordPair(VarPasswordPair varPasswordPair) {
@@ -131,21 +131,21 @@ public class MaskPasswordsConfig {
 
     /**
      * Returns the list of name/password pairs defined at the global level.
-     *
+     * 
      * <p>Modifications broughts to the returned list has no impact on this
      * configuration (the returned value is a copy). Also, the list can be
      * empty but never {@code null}.</p>
-     *
+     * 
      * @since 2.7
      */
     public List<VarPasswordPair> getGlobalVarPasswordPairs() {
         List<VarPasswordPair> r = new ArrayList<VarPasswordPair>(getGlobalVarPasswordPairsList().size());
-
+        
         // deep copy
         for(VarPasswordPair varPasswordPair: getGlobalVarPasswordPairsList()) {
             r.add((VarPasswordPair) varPasswordPair.clone());
         }
-
+        
         return r;
     }
 
@@ -153,7 +153,7 @@ public class MaskPasswordsConfig {
      * Fixes JENKINS-11514: When {@code MaskPasswordsConfig.xml} is there but was created from
      * version 2.6.1 (or older) of the plugin, {@link #globalVarPasswordPairs} can actually be
      * {@code null} ==> Always use this getter to avoid NPEs.
-     *
+     * 
      * @since 2.7.1
      */
     private List<VarPasswordPair> getGlobalVarPasswordPairsList() {

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -197,7 +197,7 @@ public class MaskPasswordsConfig {
                 maskPasswordsParamValueClasses = new LinkedHashSet<String>();
 
                 // The only way to find parameter definition/parameter value
-                // couples is to reflect the 3 methods of parameter definition
+                // couples is to reflect the methods of parameter definition
                 // classes which instantiate the parameter value.
                 // This means that this algorithm expects that the developers do
                 // clearly redefine the return type when implementing parameter
@@ -218,11 +218,17 @@ public class MaskPasswordsConfig {
                         } catch(Exception e) {
                             LOGGER.log(Level.INFO, "No createValue(String) method for " + paramDefClass);
                         }
-                        // ParameterDefinition.createValue(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObjec)
+                        // ParameterDefinition.createValue(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
                         try {
                             add(paramDefClass.getMethod("createValue", StaplerRequest.class, JSONObject.class));
                         }  catch (Exception e) {
                             LOGGER.log(Level.INFO, "No createValue(StaplerRequest, JSONObject) method for " + paramDefClass);
+                        }
+                        // ParameterDefinition.createValue(org.kohsuke.stapler.StaplerRequest)
+                        try {
+                            add(paramDefClass.getMethod("createValue", StaplerRequest.class));
+                        }  catch (Exception e) {
+                            LOGGER.log(Level.INFO, "No createValue(StaplerRequest) method for " + paramDefClass);
                         }
                     }};
 


### PR DESCRIPTION
Finalizes and enhances the original PR from @MadsNielsen. See #7 

> There is a bug in the implemetation of the isMasked(String paramValueClassName) method.
Simply put, the paramvalue (Specific class to mask) would never match the class of the getValue() method. For instance when using reflection the CredentialParameterDefinition getDefaultParameterValue() value, we get the return type to be ParameterValue...that is incorrect since the method returns a CredentialsParameterValue, which is the class name we use to check agains 'Credentials'.

https://issues.jenkins-ci.org/browse/JENKINS-25735

@reviewbybees 
