### PR TITLE
[JENKINS-25735, JENKINS-41955, etc.] Improve masking of passwords in the plugin

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -129,7 +129,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         ParametersAction params = build.getAction(ParametersAction.class);
         if(params != null) {
             for(ParameterValue param : params) {
-                if(config.isMasked(param.getClass().getName())) {
+                if(config.isMasked(param, param.getClass().getName())) {
                     EnvVars env = new EnvVars();
                     param.buildEnvironment(build, env);
                     String password = env.get(param.getName());

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -398,8 +398,19 @@ public class MaskPasswordsConfig {
                 return true;
             }
         }
-
-        return false;
+        
+        // Always mask the hudson.model.PasswordParameterValue class and its overrides
+        // This class does not comply with the criteria above, but it is sensitive starting from 1.378
+        final Class<?> valueClass;
+        try {
+            valueClass = Jenkins.getActiveInstance().getPluginManager().uberClassLoader.loadClass(paramValueClassName);
+        } catch (Exception ex) {
+            // Move on. Whatever happens here, it will blow up somewhere else
+            LOGGER.log(Level.FINE, "Failed to load class for the ParameterValue " + paramValueClassName, ex);
+            return false;
+        }
+        
+        return hudson.model.PasswordParameterValue.class.isAssignableFrom(valueClass);
     }
     
     /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -24,12 +24,12 @@
 
 package com.michelin.cio.hudson.plugins.maskpasswords;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarPasswordPair;
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarMaskRegex;
 import hudson.ExtensionList;
 import hudson.XmlFile;
 import hudson.cli.CLICommand;
-import hudson.model.Hudson;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterDefinition.ParameterDescriptor;
 import hudson.model.ParameterValue;
@@ -52,6 +52,8 @@ import javax.annotation.concurrent.GuardedBy;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -116,11 +118,7 @@ public class MaskPasswordsConfig {
 
     public MaskPasswordsConfig() {
         maskPasswordsParamDefClasses = new LinkedHashSet<String>();
-
-        // default values for the first time the config is created
-        addMaskedPasswordParameterDefinition(hudson.model.PasswordParameterDefinition.class.getName());
-        addMaskedPasswordParameterDefinition(com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition.class.getName());
-        globalVarEnableGlobally = false;
+        reset();
     }
 
     /**
@@ -172,6 +170,20 @@ public class MaskPasswordsConfig {
       globalVarEnableGlobally = state;
     }
 
+    /**
+     * Resets configuration to the default state.
+     */
+    @Restricted(NoExternalUse.class)
+    @VisibleForTesting
+    public final synchronized void reset() {
+        // Wipe the data
+        clear();
+        
+        // default values for the first time the config is created
+        addMaskedPasswordParameterDefinition(hudson.model.PasswordParameterDefinition.class.getName());
+        addMaskedPasswordParameterDefinition(com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition.class.getName()); 
+    }
+    
     public synchronized void clear() {
         maskPasswordsParamDefClasses.clear();
         getGlobalVarPasswordPairsList().clear();

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -28,6 +28,7 @@ import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.V
 import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper.VarMaskRegex;
 import hudson.ExtensionList;
 import hudson.XmlFile;
+import hudson.cli.CLICommand;
 import hudson.model.Hudson;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterDefinition.ParameterDescriptor;
@@ -297,25 +298,32 @@ public class MaskPasswordsConfig {
                         try {
                             add(paramDefClass.getMethod("getDefaultParameterValue"));
                         } catch(RuntimeException e) {
-                            LOGGER.log(Level.INFO, "No getDefaultParameterValue(String) method for " + paramDefClass);
+                            LOGGER.log(Level.INFO, "No getDefaultParameterValue(String) method for {0}", paramDefClass);
                         }
                         // ParameterDefinition.createValue(String)
+                        // This method does not exist anymore, but many classes still use it
                         try {
                             add(paramDefClass.getMethod("createValue", String.class));
                         } catch(RuntimeException e) {
-                            LOGGER.log(Level.INFO, "No createValue(String) method for " + paramDefClass);
+                            LOGGER.log(Level.INFO, "No createValue(String) method for {0}", paramDefClass);
                         }
                         // ParameterDefinition.createValue(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
                         try {
                             add(paramDefClass.getMethod("createValue", StaplerRequest.class, JSONObject.class));
                         }  catch (RuntimeException e) {
-                            LOGGER.log(Level.INFO, "No createValue(StaplerRequest, JSONObject) method for " + paramDefClass);
+                            LOGGER.log(Level.INFO, "No createValue(StaplerRequest, JSONObject) method for {0}", paramDefClass);
                         }
                         // ParameterDefinition.createValue(org.kohsuke.stapler.StaplerRequest)
                         try {
                             add(paramDefClass.getMethod("createValue", StaplerRequest.class));
-                        }  catch (Exception e) {
-                            LOGGER.log(Level.INFO, "No createValue(StaplerRequest) method for " + paramDefClass);
+                        }  catch (RuntimeException e) {
+                            LOGGER.log(Level.INFO, "No createValue(StaplerRequest) method for {0}", paramDefClass);
+                        }
+                        // ParameterDefinition.createValue(CLICommand command, String value)
+                        try {
+                            add(paramDefClass.getMethod("createValue", CLICommand.class, String.class));
+                        } catch(RuntimeException e) {
+                            LOGGER.log(Level.INFO, "No createValue(CLICommand, String) method for {0}", paramDefClass);
                         }
                     }};
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -182,7 +182,7 @@ public class MaskPasswordsConfig {
         invalidatePasswordValueClassCaches();
     }
     
-    public synchronized void invalidatePasswordValueClassCaches() {
+    /*package*/ synchronized void invalidatePasswordValueClassCaches() {
         paramValueCache_maskedClasses.clear();
         paramValueCache_nonMaskedClasses.clear();
     }

--- a/src/main/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterDefinition.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterDefinition.java
@@ -46,12 +46,6 @@ public class PasswordParameterDefinition extends ParameterDefinition {
         return value;
     }
 
-    public ParameterValue createValue(String password) {
-        PasswordParameterValue value = new PasswordParameterValue(getName(), password, getDescription());
-        value.setDescription(getDescription());
-        return value;
-    }
-
     @Override
     public ParameterValue createValue(StaplerRequest req) {
         String[] value = req.getParameterValues(getName());

--- a/src/test/java/com/michelin/cio/hudson/plugins/integrations/CorePasswordParameterTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/integrations/CorePasswordParameterTest.java
@@ -63,7 +63,7 @@ public class CorePasswordParameterTest {
     
     @Before
     public void dropCache() {
-        MaskPasswordsConfig.getInstance().clear();
+        MaskPasswordsConfig.getInstance().reset();
     }
     
     @Test
@@ -80,6 +80,22 @@ public class CorePasswordParameterTest {
         // We pass the non-existent class name in order to ensure that the Value metadata check is enough
         Assert.assertTrue( PasswordParameterValue.class + " must be masked by default",
             MaskPasswordsConfig.getInstance().isMasked(created, "nonExistent"));
+    }
+    
+    @Test
+    public void shouldMaskPasswordParameterChildrenValueByValue() {
+        ParameterValue created = new MyPasswordParameter();
+        
+        // We pass the non-existent class name in order to ensure that the Value metadata check is enough
+        Assert.assertTrue(PasswordParameterValue.class + " must be masked by default",
+            MaskPasswordsConfig.getInstance().isMasked(created, "nonExistent"));
+    }
+    
+    @Test
+    public void shouldMaskPasswordParameterChildrenValueByClass() {
+        // We pass the non-existent class name in order to ensure that the Value metadata check is enough
+        Assert.assertTrue(PasswordParameterValue.class + " must be masked by the class name",
+            MaskPasswordsConfig.getInstance().isMasked(MyPasswordParameter.class.getName()));
     }
     
     @Test
@@ -114,5 +130,14 @@ public class CorePasswordParameterTest {
         FreeStyleBuild build = j.buildAndAssertSuccess(project);
         j.assertLogContains(logWithHiddenPassword, build);
         j.assertLogNotContains(logWithClearTextPassword, build);
+    }
+    
+    private static final class MyPasswordParameter extends hudson.model.PasswordParameterValue {
+
+        private static final long serialVersionUID = 1L;
+        
+        public MyPasswordParameter() {
+            super("MYPASSWORD", "qwerty123");
+        }
     }
 }

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordConfigTests.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordConfigTests.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.michelin.cio.hudson.plugins.maskpasswords;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests of {@link MaskPasswordsConfig}.
+ * These tests do not depend on the caching being done in the Jenkins instance.
+ * @author Oleg Nenashev
+ */
+public class MaskPasswordConfigTests {
+    
+    MaskPasswordsConfig config;
+    
+    // The logic inside needs the classloader
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    
+    @Before
+    public void initConfig() {
+        config = new MaskPasswordsConfig();
+    }
+    
+    @Test
+    public void shouldConsiderAsMasked_cmchppPasswordParameterValue() {
+        assertIsMasked(com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterValue.class);   
+    }
+    
+    @Test
+    public void shouldConsiderAsMasked_hmPasswordParameterValue() {
+        assertIsMasked(hudson.model.PasswordParameterValue.class);
+    }
+    
+    @Test
+    public void shouldNotMaskTheBaseClass() {
+        assertIsNotMasked(hudson.model.ParameterValue.class);
+    }
+    
+    @Test
+    public void shouldNotMaskTheBasicParameterTypes() {
+        assertIsNotMasked(hudson.model.StringParameterValue.class);
+        assertIsNotMasked(hudson.model.FileParameterValue.class);
+    }
+    
+    private void assertIsMasked(Class<?> clazz) {
+        config.invalidatePasswordValueClassCaches();
+        assertTrue("Expected that the class is masked: " + clazz, config.guessIfShouldMask(clazz.getName()));
+    }
+    
+    private void assertIsNotMasked(Class<?> clazz) {
+        config.invalidatePasswordValueClassCaches();
+        assertFalse("Expected that the class is not masked: " + clazz, config.guessIfShouldMask(clazz.getName()));
+    }
+}

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsURLEncodingTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsURLEncodingTest.java
@@ -55,7 +55,7 @@ public class MaskPasswordsURLEncodingTest {
 
     @Before
     public void dropCache() {
-        MaskPasswordsConfig.getInstance().clear();
+        MaskPasswordsConfig.getInstance().reset();
     }
     
     @Test

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsURLEncodingTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsURLEncodingTest.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Set;
 import java.util.TreeSet;
+import org.junit.Before;
 
 @Issue("JENKINS-34908")
 public class MaskPasswordsURLEncodingTest {
@@ -52,7 +53,11 @@ public class MaskPasswordsURLEncodingTest {
     @Rule
     public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
-
+    @Before
+    public void dropCache() {
+        MaskPasswordsConfig.getInstance().clear();
+    }
+    
     @Test
     public void passwordMaskedEncoded() throws Exception {
         story.addStep(new Statement() {

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -188,44 +188,7 @@ public class MaskPasswordsWorkflowTest {
         });
     }
     
-    @Test
-    public void passwordParameterMask() throws Exception {
-        story.addStep(new Statement() {
-            String clearTextPassword = "myClearTextPassword";
-            String logWithClearTextPassword = "printed " + clearTextPassword + " oops";
-            String logWithHiddenPassword = "printed ******** oops";
-            
-            @Override
-            public void evaluate() throws Throwable {
-                FreeStyleProject project =
-                        story.j.jenkins.createProject(FreeStyleProject.class, "testPasswordParameter");
-                
-                PasswordParameterDefinition passwordParameterDefinition =
-                        new PasswordParameterDefinition("Password1", clearTextPassword, null);
-                ParametersDefinitionProperty parametersDefinitionProperty =
-                        new ParametersDefinitionProperty(passwordParameterDefinition);
-                project.addProperty(parametersDefinitionProperty);
-                
-                MaskPasswordsBuildWrapper maskPasswordsBuildWrapper =
-                        new MaskPasswordsBuildWrapper(Collections.<MaskPasswordsBuildWrapper.VarPasswordPair>emptyList());
-                project.getBuildWrappersList().add(maskPasswordsBuildWrapper);
-                
-                project.getBuildersList().add(new TestBuilder() {
-                    @Override
-                    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-                        listener.getLogger().println(logWithClearTextPassword);
-                        build.setResult(Result.SUCCESS);
-                        return true;
-                    }
-                });
-                
-                FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
-                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(build));
-                story.j.assertLogContains(logWithHiddenPassword, build);
-                story.j.assertLogNotContains(logWithClearTextPassword, build);
-            }
-        });
-    }
+
 
     // Copied from credentials-binding-plugin; perhaps belongs in JenkinsRule?
     private static Set<String> grep(File dir, String text) throws IOException {

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -66,7 +66,7 @@ public class MaskPasswordsWorkflowTest {
 
     @Before
     public void dropCache() {
-        MaskPasswordsConfig.getInstance().clear();
+        MaskPasswordsConfig.getInstance().reset();
     }
     
     @Test

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -47,6 +47,7 @@ import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runners.model.Statement;
@@ -63,6 +64,11 @@ public class MaskPasswordsWorkflowTest {
     @Rule
     public RestartableJenkinsRule story = new RestartableJenkinsRule();
 
+    @Before
+    public void dropCache() {
+        MaskPasswordsConfig.getInstance().clear();
+    }
+    
     @Test
     public void configRoundTrip() throws Exception {
         story.addStep(new Statement() {

--- a/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
@@ -31,15 +31,17 @@ import hudson.model.BuildListener;
 import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
+import hudson.util.Secret;
 import java.io.IOException;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -62,6 +64,17 @@ public class PasswordParameterTest {
     public void shouldMaskPasswordParameterClassByDefault() {
         Assert.assertTrue( PasswordParameterValue.class + " must be masked by default",
             MaskPasswordsConfig.getInstance().isMasked(PasswordParameterValue.class.getName()));
+    }
+    
+    @Test
+    @Issue("JENKINS-41955")
+    public void shouldMaskPasswordParameterValueByDefault() {
+        PasswordParameterDefinition d = new PasswordParameterDefinition("FOO", "BAR");
+        ParameterValue created = d.createValue(Secret.fromString("hello"));
+        
+        // We pass the non-existent class name in order to ensure that the Value metadata check is enough
+        Assert.assertTrue( PasswordParameterValue.class + " must be masked by default",
+            MaskPasswordsConfig.getInstance().isMasked(created, "nonExistent"));
     }
     
     @Test

--- a/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
@@ -39,6 +39,7 @@ import hudson.util.Secret;
 import java.io.IOException;
 import java.util.Collections;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +59,11 @@ public class PasswordParameterTest {
     
     @Rule
     public JenkinsRule j = new JenkinsRule();
+    
+    @Before
+    public void dropCache() {
+        MaskPasswordsConfig.getInstance().clear();
+    }
     
     @Test
     @Issue("JENKINS-41955")

--- a/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Jenkins contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.michelin.cio.hudson.plugins.passwordparam;
+
+import com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsBuildWrapper;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+/**
+ * Tests of {@link PasswordParameterValue} and {@link PasswordParameterDefinition}.
+ * @author bpmarinho
+ */
+public class PasswordParameterTest {
+    
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    
+    @Test
+    @Issue("JENKINS-41955")
+    public void passwordParameterShouldBeMaskedInFreestyleProject() throws Exception {
+        story.addStep(new Statement() {
+            String clearTextPassword = "myClearTextPassword";
+            String logWithClearTextPassword = "printed " + clearTextPassword + " oops";
+            String logWithHiddenPassword = "printed ******** oops";
+            
+            @Override
+            public void evaluate() throws Throwable {
+                FreeStyleProject project =
+                        story.j.jenkins.createProject(FreeStyleProject.class, "testPasswordParameter");
+                
+                hudson.model.PasswordParameterDefinition passwordParameterDefinition =
+                        new hudson.model.PasswordParameterDefinition("Password1", clearTextPassword, null);
+                ParametersDefinitionProperty parametersDefinitionProperty =
+                        new ParametersDefinitionProperty(passwordParameterDefinition);
+                project.addProperty(parametersDefinitionProperty);
+                
+                MaskPasswordsBuildWrapper maskPasswordsBuildWrapper =
+                        new MaskPasswordsBuildWrapper(Collections.<MaskPasswordsBuildWrapper.VarPasswordPair>emptyList());
+                project.getBuildWrappersList().add(maskPasswordsBuildWrapper);
+                
+                project.getBuildersList().add(new TestBuilder() {
+                    @Override
+                    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                        listener.getLogger().println(logWithClearTextPassword);
+                        build.setResult(Result.SUCCESS);
+                        return true;
+                    }
+                });
+                
+                FreeStyleBuild build = project.scheduleBuild2(0, new Cause.UserIdCause()).get();
+                story.j.assertBuildStatusSuccess(story.j.waitForCompletion(build));
+                story.j.assertLogContains(logWithHiddenPassword, build);
+                story.j.assertLogNotContains(logWithClearTextPassword, build);
+            }
+        });
+    }
+}


### PR DESCRIPTION

- [x] Rework the broken implementation of the `ParameterValue` classes aching in `MaskPasswordConfig`. The implementation was unreliable since Mask Password `2.5`
- [x] Rework the mechanism of guessing sensitive `ParameterValue`s by classnames of `ParameterDefinition`s. This is still an architecture bug IMHO, but now the engine guesses classes more reliably using all available `ParameterDefinition` method overrides
- [x] [JENKINS-41955](https://issues.jenkins-ci.org/browse/JENKINS-41955) - Replace the hotfix made by @bpmarinho in https://github.com/jenkinsci/mask-passwords-plugin/pull/11 . The new parameter value implementation guesses the case reliably
- [x] [JENKINS-25735](https://issues.jenkins-ci.org/browse/JENKINS-25735) - Always consider sensitive parameter values as values, which require masking
- [x] Tests, Tests, Tests

Likely the change also solves many other issues reported to the plugin. Still need direct tests for them BTW.

@reviewbybees @bpmarinho @brockoffdev I would appreciate reviews and manual testing
