### PR TITLE
Performance enhancement for MaskPasswords (specifically pair cloning)

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -235,25 +235,15 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         @DataBoundConstructor
         public VarPasswordPair(String var, String password) {
             this.var = var;
-            this.password = Secret.fromString(password);
-        }
-
-        /**
-         * Allow construction from a Secret object - this allows deep cloning without the overhead of an
-         * attempted (and failed) decryption cycle which throws an exception and the related overhead which
-         * can cause a massive overhead on an instance with many global mask passwords and jobs (especially
-         * when combined with the BuildPipeline plugin).
-         */
-        public VarPasswordPair(String var, Secret password) {
-            this.var = var;
-            this.password = password;
+            // Adding MAGIC on the end prevents an attempted decrypt and the associated exception overhead
+            this.password = Secret.fromString(password + Secret.MAGIC);
         }
 
         @Override
         @SuppressFBWarnings(value = "CN_IDIOM_NO_SUPER_CALL", justification = "We do not expect anybody to use this class."
                 + "If they do, they must override clone() as well")
         public Object clone() {
-            return new VarPasswordPair(getVar(), new Secret(getPassword()));
+            return new VarPasswordPair(getVar(), getPassword());
         }
 
         @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -238,11 +238,22 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             this.password = Secret.fromString(password);
         }
 
+        /**
+         * Allow construction from a Secret object - this allows deep cloning without the overhead of an
+         * attempted (and failed) decryption cycle which throws an exception and the related overhead which
+         * can cause a massive overhead on an instance with many global mask passwords and jobs (especially
+         * when combined with the BuildPipeline plugin).
+         */
+        public VarPasswordPair(String var, Secret password) {
+            this.var = var;
+            this.password = password;
+        }
+
         @Override
         @SuppressFBWarnings(value = "CN_IDIOM_NO_SUPER_CALL", justification = "We do not expect anybody to use this class."
                 + "If they do, they must override clone() as well")
         public Object clone() {
-            return new VarPasswordPair(getVar(), getPassword());
+            return new VarPasswordPair(getVar(), new Secret(getPassword()));
         }
 
         @Override


### PR DESCRIPTION
``` clone() ``` method currently involves an attempted decrypt of an already decrypted String. This causes a general security exception to be thrown resulting in a performance hit. In some scenarios (such as build pipelines with parameterized triggers and several global mask passwords) there can be a significant volume of calls to the clone method.
The solution is to create an additional constructor used by the (deep) ``` clone() ``` method avoiding the un-necessary attempted decrypt.

Some quick benchmarks on my system result in an approximately 30x speed-up:
```
Running 100,000 old iterations...
Old method took 6,266ms

Running 100,000 new iterations...
New method took 213ms
```