### PR TITLE
Approximately 30x performance improvement for VarPasswordPair clone

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -235,25 +235,15 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         @DataBoundConstructor
         public VarPasswordPair(String var, String password) {
             this.var = var;
-            this.password = Secret.fromString(password);
-        }
-
-        /**
-         * Allow construction from a Secret object - this allows deep cloning without the overhead of an
-         * attempted (and failed) decryption cycle which throws an exception and the related overhead which
-         * can cause a massive overhead on an instance with many global mask passwords and jobs (especially
-         * when combined with the BuildPipeline plugin).
-         */
-        public VarPasswordPair(String var, Secret password) {
-            this.var = var;
-            this.password = password;
+            // Adding MAGIC on the end prevents an attempted decrypt and the associated exception overhead
+            this.password = Secret.fromString(password + Secret.MAGIC);
         }
 
         @Override
         @SuppressFBWarnings(value = "CN_IDIOM_NO_SUPER_CALL", justification = "We do not expect anybody to use this class."
                 + "If they do, they must override clone() as well")
         public Object clone() {
-            return new VarPasswordPair(getVar(), new Secret(getPassword()));
+            return new VarPasswordPair(getVar(), getPassword());
         }
 
         @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -246,10 +246,11 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
              * trigger
              */
             this.var = var;
+            Secret t = null;
             try {
-                Secret t = getSecretConstructor().newInstance(password);
+                t = getSecretConstructor().newInstance(password);
             } catch (Exception e) {
-                Secret t = Secret.fromString(password);
+                t = Secret.fromString(password);
             }
             this.password = t;
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -298,12 +298,17 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         
         public static Constructor<Secret> getSecretConstructor() throws NoSuchMethodException {
             if (SECRET_CONSTRUCTOR==null) {
-                SECRET_CONSTRUCTOR = Secret.class.getDeclaredConstructor(String.class);
-                SECRET_CONSTRUCTOR.setAccessible(true);
+                synchronized (lock) {
+                    if (SECRET_CONSTRUCTOR==null) {
+                        SECRET_CONSTRUCTOR = Secret.class.getDeclaredConstructor(String.class);
+                        SECRET_CONSTRUCTOR.setAccessible(true);
+                    }
+                }
             }
             return SECRET_CONSTRUCTOR;
         }
         
+        private static final Object lock = new Object();
         private static Constructor<Secret> SECRET_CONSTRUCTOR;
     }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -289,7 +289,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         }
         
         public static Constructor<Secret> getSecretConstructor() {
-            if (SECRET_CONSTRUCTOR!=null) {
+            if (SECRET_CONSTRUCTOR==null) {
                 SECRET_CONSTRUCTOR = Secret.class.getDeclaredConstructor(String.class);
                 SECRET_CONSTRUCTOR.setAccessible(true);
             }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -247,10 +247,11 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
              */
             this.var = var;
             try {
-                this.password = getSecretConstructor().newInstance(password);
+                Secret t = getSecretConstructor().newInstance(password);
             } catch (Exception e) {
-                this.password = Secret.fromString(password);
+                Secret t = Secret.fromString(password);
             }
+            this.password = t;
         }
 
         @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -239,7 +239,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             this.password = Secret.fromString(password);
         }
 
-        public VarPasswordPair(String var, String password, boolean fastMethod) throws InstantiationException {
+        public VarPasswordPair(String var, String password, boolean fastMethod) {
             if (fastMethod) {
                 /**
                  * Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt
@@ -247,7 +247,11 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
                  * trigger
                  */
                 this.var = var;
-                this.password = getSecretConstructor().newInstance(password);
+                try {
+                    this.password = getSecretConstructor().newInstance(password);
+                } catch (Exception e) {
+                    // forget about it!
+                }
             } else {
                 this.var = var;
                 this.password = Secret.fromString(password);

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -235,8 +235,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         @DataBoundConstructor
         public VarPasswordPair(String var, String password) {
             this.var = var;
-            // Adding MAGIC on the end prevents an attempted decrypt and the associated exception overhead
-            this.password = Secret.fromString(password + Secret.MAGIC);
+            this.password = Secret.fromString(password);
         }
 
         @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -249,8 +249,6 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             try {
                 this.password = getSecretConstructor().newInstance(password);
             } catch (Exception e) {
-                // forget about it!
-            } finally {
                 this.password = Secret.fromString(password);
             }
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -238,11 +238,22 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             this.password = Secret.fromString(password);
         }
 
+        /**
+         * Allow construction from a Secret object - this allows deep cloning without the overhead of an
+         * attempted (and failed) decryption cycle which throws an exception and the related overhead which
+         * can cause a massive overhead on an instance with many global mask passwords and jobs (especially
+         * when combined with the BuildPipeline plugin).
+         */
+        public VarPasswordPair(String var, Secret password) {
+            this.var = var;
+            this.password = password;
+        }
+
         @Override
         @SuppressFBWarnings(value = "CN_IDIOM_NO_SUPER_CALL", justification = "We do not expect anybody to use this class."
                 + "If they do, they must override clone() as well")
         public Object clone() {
-            return new VarPasswordPair(getVar(), getPassword());
+            return new VarPasswordPair(getVar(), new Secret(getPassword()));
         }
 
         @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -296,15 +296,11 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             return hash;
         }
         
-        public static Constructor<Secret> getSecretConstructor() throws NoSuchMethodException {
+        public static synchronized Constructor<Secret> getSecretConstructor() throws NoSuchMethodException {
             if (SECRET_CONSTRUCTOR==null) {
-                synchronized (lock) {
-                    if (SECRET_CONSTRUCTOR==null) {
-                        Constructor<Secret> t = Secret.class.getDeclaredConstructor(String.class);
-                        t.setAccessible(true);
-                        SECRET_CONSTRUCTOR = t;
-                    }
-                }
+                    Constructor<Secret> t = Secret.class.getDeclaredConstructor(String.class);
+                    t.setAccessible(true);
+                    SECRET_CONSTRUCTOR = t;
             }
             return SECRET_CONSTRUCTOR;
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -233,17 +233,22 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         private final Secret password;
 
         @DataBoundConstructor
-        public VarPasswordPair(String var, String password, boolean fastMethod=false) {
+        public VarPasswordPair(String var, String password) {
             this.var = var;
+            this.password = Secret.fromString(password);
+        }
+
+        public VarPasswordPair(String var, String password, boolean fastMethod) {
             if (fastMethod) {
                 /**
                  * Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt
                  * an already decrypted string. This is a massive performance hit in some scenarios (e.g. build pipeline, parameterized
                  * trigger
                  */
+                this.var = var;
                 this.password = getSecretConstructor().newInstance(password);
             } else {
-                this.password = Secret.fromString(password);
+                this(var,password);
             }
         }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -240,21 +240,17 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         }
 
         public VarPasswordPair(String var, String password, boolean fastMethod) {
-            if (fastMethod) {
-                /**
-                 * Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt
-                 * an already decrypted string. This is a massive performance hit in some scenarios (e.g. build pipeline, parameterized
-                 * trigger
-                 */
-                this.var = var;
-                try {
-                    this.password = getSecretConstructor().newInstance(password);
-                } catch (Exception e) {
-                    // forget about it!
-                }
-            } else {
-                this.var = var;
-                this.password = Secret.fromString(password);
+            /**
+             * Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt
+             * an already decrypted string. This is a massive performance hit in some scenarios (e.g. build pipeline, parameterized
+             * trigger
+             */
+            this.var = var;
+            this.password = null;
+            try {
+                this.password = getSecretConstructor().newInstance(password);
+            } catch (Exception e) {
+                // forget about it!
             }
         }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -239,7 +239,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             this.password = Secret.fromString(password);
         }
 
-        public VarPasswordPair(String var, String password, boolean fastMethod) {
+        public VarPasswordPair(String var, String password, boolean fastMethod) throws InstantiationException {
             if (fastMethod) {
                 /**
                  * Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt
@@ -295,7 +295,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             return hash;
         }
         
-        public static Constructor<Secret> getSecretConstructor() {
+        public static Constructor<Secret> getSecretConstructor() throws NoSuchMethodException {
             if (SECRET_CONSTRUCTOR==null) {
                 SECRET_CONSTRUCTOR = Secret.class.getDeclaredConstructor(String.class);
                 SECRET_CONSTRUCTOR.setAccessible(true);

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -300,8 +300,9 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
             if (SECRET_CONSTRUCTOR==null) {
                 synchronized (lock) {
                     if (SECRET_CONSTRUCTOR==null) {
-                        SECRET_CONSTRUCTOR = Secret.class.getDeclaredConstructor(String.class);
-                        SECRET_CONSTRUCTOR.setAccessible(true);
+                        Constructor<Secret> t = Secret.class.getDeclaredConstructor(String.class);
+                        t.setAccessible(true);
+                        SECRET_CONSTRUCTOR = t;
                     }
                 }
             }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -48,6 +48,7 @@ import hudson.util.Secret;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +249,8 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
                 this.var = var;
                 this.password = getSecretConstructor().newInstance(password);
             } else {
-                this(var,password);
+                this.var = var;
+                this.password = Secret.fromString(password);
             }
         }
 

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -246,11 +246,12 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
              * trigger
              */
             this.var = var;
-            this.password = null;
             try {
                 this.password = getSecretConstructor().newInstance(password);
             } catch (Exception e) {
                 // forget about it!
+            } finally {
+                this.password = Secret.fromString(password);
             }
         }
 


### PR DESCRIPTION
**There's questionable use of reflection to make this work!**
**I do NOT recommend merging this; I'm just raising the PR to have it tested & visible to others!**

Fast method is used when cloning to avoid the performance hit of throwing an exception when attempting to decrypt an already decrypted string. This is a massive performance hit in some scenarios (e.g. build pipeline, parameterized trigger).

