### PR TITLE
use modern api in ConsoleLogFilter to allow for pipeline jobs to be filtered globally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <version>2.11.1-SNAPSHOT</version>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.642.4</jenkins.version>
     <java.level>7</java.level>
     <workflow.version>1.8</workflow.version>
   </properties>

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -30,6 +30,7 @@ import hudson.model.Run;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -42,7 +43,9 @@ import java.util.logging.Logger;
  * @author Jason Antman jason@jasonantman.com
  */
 @Extension
-public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter {
+public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter  implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public MaskPasswordsConsoleLogFilter() {
     // nothing to do here; this object lives for the lifetime of Jenkins,

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -24,43 +24,16 @@
 
 package com.michelin.cio.hudson.plugins.maskpasswords;
 
-import com.thoughtworks.xstream.converters.Converter;
-import com.thoughtworks.xstream.converters.MarshallingContext;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
-import com.thoughtworks.xstream.io.HierarchicalStreamReader;
-import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.console.ConsoleLogFilter;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
 import hudson.model.Run;
-import hudson.model.TaskListener;
-import hudson.tasks.BuildWrapperDescriptor;
-import hudson.util.Secret;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.tasks.SimpleBuildWrapper;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-import org.jvnet.localizer.Localizable;
-import org.jvnet.localizer.ResourceBundleHolder;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * GLOBAL Console Log Filter that alters the console so that passwords don't
@@ -79,7 +52,7 @@ public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter {
 
   @SuppressWarnings("rawtypes")
   @Override
-  public OutputStream decorateLogger(AbstractBuild _ignore, OutputStream logger) throws IOException, InterruptedException {
+  public OutputStream decorateLogger(Run _ignore, OutputStream logger) throws IOException, InterruptedException {
       // check the config
       MaskPasswordsConfig config = MaskPasswordsConfig.getInstance();
       if(! config.isEnabledGlobally()) {


### PR DESCRIPTION
When enabled globally it should work with all types of Jobs, also pipelines. Depends on JENKINS-45693 or that JENKINS-38381 implements this.