### PR TITLE
Removed daring "view build parameters" value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ work
 .settings
 .classpath
 .project
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ work
 .classpath
 .project
 
+# Intellij project files
 .idea

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>mask-passwords</artifactId>
   <packaging>hpi</packaging>
   <name>Mask Passwords Plugin</name>
-  <description>Masks passwords that may appear in the console</description>
+  <description>Masks passwords that may appear in the console. Provides non-stored password parameter.</description>
   <url>https://wiki.jenkins.io/display/JENKINS/Mask+Passwords+Plugin</url>
   <version>2.12.1-SNAPSHOT</version>
 

--- a/src/main/resources/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue/value.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue/value.jelly
@@ -27,6 +27,6 @@
         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <f:entry title="${it.name}" description="${it.description}">
-        <f:textbox name="value" readonly="true"/>
+        <f:textbox name="value" value="${%non-stored password parameter}" readonly="true"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue/value.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/passwordparam/PasswordParameterValue/value.jelly
@@ -27,6 +27,6 @@
         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <f:entry title="${it.name}" description="${it.description}">
-        <f:textbox name="value" value="${%You really think you can access this value?}" readonly="true"/>
+        <f:textbox name="value" readonly="true"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -25,4 +25,5 @@
 <?jelly escape-by-default='true'?>
 <div>
     This plugin allows masking passwords that may appear in the console.
+    The plugin also provides a non-stored password parameter.
 </div>


### PR DESCRIPTION
1. Changed plugin description (added information about non-stored password).
2. Edited daring "view build parameters" value "You really think you can access this value?" to "non-stored password parameter".

When I press "see build parameters" I see "You really think you can access this value?". This question is quite daring and it is better to remove or change it. My clients always asks me to remove this question or replace with some other value.