### PR TITLE
[SECURITY-157] Fix global mask passwords config

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
@@ -51,7 +51,7 @@
                         </td>
                         <td width="10%" align="right">${%Password}</td>
                         <td width="30%">
-                            <f:password name="globalVarPasswordPair.password" value="${!empty globalVarPasswordPair.password?globalVarPasswordPair.password:''}"/>
+                            <f:password name="globalVarPasswordPair.password" value="${!empty globalVarPasswordPair.passwordAsSecret?globalVarPasswordPair.passwordAsSecret.encryptedValue:''}"/>
                         </td>
                         <td width="20%" align="right"><f:repeatableDeleteButton/></td>
                     </tr>


### PR DESCRIPTION
Since the security issue has been public for several months, there's no need to hide proposing the fix.

This fixes the global configuration page by displaying the encrypted values of global password variables instead of plaintext within the password form.

See also:

- [SECURITY-157][SECURITY-157] (description unknown to me)
- [security advisory published 2019-08-07][advisory]

[advisory]: https://jenkins.io/security/advisory/2019-08-07/#SECURITY-157
[SECURITY-157]: https://issues.jenkins-ci.org/browse/SECURITY-157