### PR TITLE
JENKINS-64523 Jenkins core >2.263 fixes

### DIFF
--- a/docs/CHANGELOG.old.md
+++ b/docs/CHANGELOG.old.md
@@ -134,7 +134,7 @@ Release Date: (10/20/2011)
 -   Implemented
     [JENKINS-11399](https://issues.jenkins-ci.org/browse/JENKINS-11399):
     It is now possible to define name/password pairs in Jenkins' main
-    configuration screen (**Manage Hudson** \> **Configure System**)
+    configuration screen (**Manage Jenkins** \> **Configure System**)
 
 ## Version 2.6.1
 
@@ -156,7 +156,7 @@ Release Date: (04/29/2011)
 
 Release Date: (03/11/2011)
 
--   New configuration screen (in **Manage Hudson** \> **Configure
+-   New configuration screen (in **Manage Jenkins** \> **Configure
     System**) allowing to select which build parameters have to be
     masked (**Password Parameter** are selected by default)
 -   Fixed a bug which was preventing to mask passwords containing

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ this:
 
 When activating the **Mask passwords** option in a job, the builds'
 **Password Parameters** (or any other type of build parameters selected
-for masking in **Manage Hudson** \> **Configure System**) are
+for masking in **Manage Jenkins** \> **Configure System**) are
 automatically masked from the console. Furthermore, you can also safely
 define a list of static passwords to be masked (you can also define a
 list of static password shared by all jobs in Jenkins' main
@@ -53,7 +53,7 @@ output:
 
 # User guide
 
-First, go to Jenkins' main configuration screen (**Manage Hudson** \>
+First, go to Jenkins' main configuration screen (**Manage Jenkins** \>
 **Configure System**) and select, in the **Mask Passwords -
 Configuration** section, which kind of build parameters have to be
 automatically masked from the console output:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>Mask Passwords Plugin</name>
   <description>Masks passwords that may appear in the console. Provides non-stored password parameter.</description>
   <url>https://github.com/jenkinsci/mask-passwords-plugin</url>
-  <version>2.14-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
 
   <properties>
     <jenkins.version>2.272</jenkins.version>
@@ -119,4 +119,3 @@
     </dependencies>
 </project>  
   
-

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.5</version>
+    <version>4.15</version>
   </parent>
 
   <artifactId>mask-passwords</artifactId>
@@ -15,9 +15,10 @@
   <version>2.14-SNAPSHOT</version>
 
   <properties>
-    <jenkins.version>1.642.4</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.272</jenkins.version>
+    <java.level>8</java.level>
     <workflow.version>1.8</workflow.version>
+    <useBeta>true</useBeta> <!-- CustomDescribableModel -->
   </properties>
 
   <scm>
@@ -66,42 +67,52 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>20</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -294,6 +294,10 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         }
 
         @Extension
+        /**
+         * {@link CustomDescribableModel} is needed because pipeline doesn't natively support the {@link Secret} class
+         * but we need Secret so that data-binding works correctly.
+         */
         public static class DescriptorImpl extends Descriptor<VarPasswordPair> implements CustomDescribableModel {
             @Nonnull
             @Override

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -147,7 +147,7 @@ public class MaskPasswordsConfig {
      */
     public void addGlobalVarPasswordPair(VarPasswordPair varPasswordPair) {
         // blank values are forbidden
-        if(StringUtils.isBlank(varPasswordPair.getVar()) || StringUtils.isBlank(varPasswordPair.getPassword())) {
+        if(StringUtils.isBlank(varPasswordPair.getVar()) || varPasswordPair.getPlainTextPassword() == null) {
             LOGGER.fine("addGlobalVarPasswordPair NOT adding pair with null var or password");
             return;
         }
@@ -225,7 +225,7 @@ public class MaskPasswordsConfig {
     }
 
     private static XmlFile getConfigFile() {
-        return new XmlFile(new File(Jenkins.getActiveInstance().getRootDir(), CONFIG_FILE));
+        return new XmlFile(new File(Jenkins.get().getRootDir(), CONFIG_FILE));
     }
 
     /**

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -71,7 +71,7 @@ public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter  implements 
       // global passwords
       List<MaskPasswordsBuildWrapper.VarPasswordPair> globalVarPasswordPairs = config.getGlobalVarPasswordPairs();
       for(MaskPasswordsBuildWrapper.VarPasswordPair globalVarPasswordPair: globalVarPasswordPairs) {
-          passwords.add(globalVarPasswordPair.getPassword());
+          passwords.add(globalVarPasswordPair.getPlainTextPassword());
       }
 
       // global regexes

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
@@ -24,54 +24,26 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <tr>
-        <td/>
-        <td colspan="2">
-            <div class="help" style="display:block;background-color:#F7F1DA;">
-                ${%HowToConfigureThisPlugin}
-            </div>
-        </td>
-        <td/>
-    </tr>
-    <tr>
-        <td/>
-        <td colspan="2">${%PasswordPairTitle}</td>
-        <td/>
-    </tr>
-    <f:entry field="varPasswordPairs">
-        <f:repeatable name="varPasswordPairs" items="${instance.varPasswordPairs}" var="varPasswordPair">
-            <table width="100%">
-                <tr>
-                    <td width="10%" align="right">${%Name}</td>
-                    <td width="30%">
-                        <f:textbox name="varPasswordPair.var" value="${!empty varPasswordPair.var?varPasswordPair.var:''}"/>
-                    </td>
-                    <td width="10%" align="right">${%Password}</td>
-                    <td width="30%">
-                        <f:password name="varPasswordPair.password" value="${varPasswordPair.passwordAsSecret}"/>
-                    </td>
-                    <td width="20%" align="right"><f:repeatableDeleteButton/></td>
-                </tr>
-            </table>
+    <div class="help" style="display:block;background-color:#F7F1DA;">
+        ${%HowToConfigureThisPlugin}
+    </div>
+    <f:entry title="${%PasswordPairTitle}">
+        <f:repeatable field="varPasswordPairs">
+            <f:entry title="${%Name}" field="var">
+                <f:textbox />
+            </f:entry>
+            <f:entry title="${%Password}" field="password">
+                <f:password />
+            </f:entry>
+            <div align="right"><f:repeatableDeleteButton/></div>
         </f:repeatable>
     </f:entry>
-    <!-- regexes -->
-    <tr>
-        <td/>
-        <td colspan="2">${%RegexTitle}</td>
-        <td/>
-    </tr>
-    <f:entry field="varMaskRegexes">
-        <f:repeatable name="varMaskRegexes" items="${instance.varMaskRegexes}" var="varMaskRegex">
-            <table width="100%">
-                <tr>
-                    <td width="10%" align="right">${%Regex}</td>
-                    <td width="70%">
-                        <f:textbox name="varMaskRegex.regex" value="${!empty varMaskRegex.regex?varMaskRegex.regex:''}"/>
-                    </td>
-                    <td width="20%" align="right"><f:repeatableDeleteButton/></td>
-                </tr>
-            </table>
+    <f:entry title="${%RegexTitle}">
+        <f:repeatable field="varMaskRegexes">
+            <f:entry title="${%Regex}" field="regex">
+                <f:textbox />
+            </f:entry>
+            <div align="right"><f:repeatableDeleteButton/></div>
         </f:repeatable>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.properties
@@ -21,8 +21,8 @@
 # THE SOFTWARE.
 
 HowToConfigureThisPlugin=<strong>Password Parameter</strong>s, or any other \
-    type of build parameters or regexes selected for masking in Hudson''s/Jenkins'' main \
-    configuration screen (<strong>Manage Hudson</strong> > <strong>Configure \
+    type of build parameters or regexes selected for masking in Jenkins'' main \
+    configuration screen (<strong>Manage Jenkins</strong> > <strong>Configure \
     System</strong>), will be automatically masked.
 PasswordPairTitle=Name/Password Pairs
 RegexTitle=Regular Expressions

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/global.jelly
@@ -24,55 +24,37 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <!-- global enable -->
-    <f:section title="${%EnabledGlobally}">
-      <f:entry title="${%Enable Mask Passwords for ALL BUILDS}" description="${%High possibility of breaking things; use this only as a last resort. Read help before enabling!}" field="globalVarMaskEnabledGlobally">
-          <f:checkbox checked="${descriptor.config.isEnabledGlobally()}" />
-      </f:entry>
-    </f:section>
     <!-- parameter definitions to be automatically masked -->
-    <f:section title="${%ParameterDefinitions}">
+    <f:section title="${%Mask Passwords}">
+        <f:entry title="${%Enable Mask Passwords for ALL BUILDS}" description="${%High possibility of breaking things; use this only as a last resort. Read help before enabling!}" field="globalVarMaskEnabledGlobally">
+            <f:checkbox checked="${descriptor.config.isEnabledGlobally()}" />
+        </f:entry>
+        <!-- global var/password pairs -->
+        <f:entry title="${%GlobalVarPasswordPairs}">
+            <f:repeatable field="globalVarPasswordPairs">
+                <f:entry title="${%Name}" field="var">
+                    <f:textbox />
+                </f:entry>
+                <f:entry title="${%Password}" field="password">
+                    <f:password />
+                </f:entry>
+                <div align="right"><f:repeatableDeleteButton/></div>
+            </f:repeatable>
+        </f:entry>
+        <!-- global regexes -->
+        <f:entry title="${%GlobalVarMaskRegexes}">
+            <f:repeatable field="globalVarMaskRegexes">
+                <f:entry title="${%Regex}" field="regex">
+                    <f:textbox />
+                </f:entry>
+                <div align="right"><f:repeatableDeleteButton/></div>
+            </f:repeatable>
+        </f:entry>
         <j:forEach var="paramDef" items="${descriptor.config.parameterDefinitions}">
             <f:entry title="${paramDef.value}">
                 <input type="hidden" name="maskedParamDefs" value="${paramDef.key}"/>
                 <f:checkbox name="selectedMaskedParamDefs" checked="${descriptor.config.isSelected(paramDef.key)}"/>
             </f:entry>
         </j:forEach>
-    </f:section>
-    <!-- global var/password pairs -->
-    <f:section title="${%GlobalVarPasswordPairs}">
-        <f:entry field="globalVarPasswordPairs">
-            <f:repeatable name="globalVarPasswordPairs" items="${descriptor.config.globalVarPasswordPairs}" var="globalVarPasswordPair">
-                <table width="100%">
-                    <tr>
-                        <td width="10%" align="right">${%Name}</td>
-                        <td width="30%">
-                            <f:textbox name="globalVarPasswordPair.var" value="${!empty globalVarPasswordPair.var?globalVarPasswordPair.var:''}"/>
-                        </td>
-                        <td width="10%" align="right">${%Password}</td>
-                        <td width="30%">
-                            <f:password name="globalVarPasswordPair.password" value="${!empty globalVarPasswordPair.passwordAsSecret?globalVarPasswordPair.passwordAsSecret.encryptedValue:''}"/>
-                        </td>
-                        <td width="20%" align="right"><f:repeatableDeleteButton/></td>
-                    </tr>
-                </table>
-            </f:repeatable>
-        </f:entry>
-    </f:section>
-    <!-- global regexes -->
-    <f:section title="${%GlobalVarMaskRegexes}">
-        <f:entry field="globalVarMaskRegexes">
-            <f:repeatable name="globalVarMaskRegexes" items="${descriptor.config.globalVarMaskRegexes}" var="globalVarMaskRegex">
-                <table width="100%">
-                    <tr>
-                        <td width="10%" align="right">${%Regex}</td>
-                        <td width="70%">
-                            <f:textbox name="globalVarMaskRegex.regex" value="${!empty globalVarMaskRegex.regex?globalVarMaskRegex.regex:''}"/>
-                        </td>
-                        <td width="20%" align="right"><f:repeatableDeleteButton/></td>
-                    </tr>
-                </table>
-            </f:repeatable>
-        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help-globalVarMaskEnabledGlobally.html
@@ -2,6 +2,6 @@
     If checked, the a MaskPasswordsConsoleLogFilter will be injected into EVERY Build, regardless of the Project's settings.
     This is generally bad practice, but if your foremost concern is having secrets hidden, it may be worth trying. Note that
     this should be tested with your jobs before being relied on; it's possible that custom Job types will not honor this.
-    Workflow jobs in Jenkins versions before 1.632 will not honor this
-    (see <a href="https://issues.jenkins-ci.org/browse/JENKINS-30777">JENKINS-30777</a>).
+    Pipeline jobs are not currently supported, vote for <a href="https://issues.jenkins-ci.org/browse/JENKINS-30777">JENKINS-30777</a>)
+    if you really need this functionality.
 </div>

--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/help.html
@@ -26,10 +26,10 @@
 <div>
     <p>When enabled, allows masking passwords that may appear in the console.</p>
     <p>Passwords or regexes to be masked can be defined at three levels.</p>
-    <p>First, it is possible to select in Hudson's/Jenkins' configuration screen
+    <p>First, it is possible to select in Jenkins configuration screen
     the build parameters whose value must be masked. For example, selecting the
     <b>Password Parameter</b> type is a good idea.</p>
-    <p>Second, still in Hudson's/Jenkins' configuration screen, it is possible
+    <p>Second, still in Jenkins' configuration screen, it is possible
     to define passwords to be masked as global <b>Name</b>/<b>Password</b>
     pairs, or regexes to be masked.</p>
     <p>Third, on a per job basis (that is, in the current configuration screen),


### PR DESCRIPTION
* Replace Hudson mentions with Jenkins
* Add `@Symbol` to the build wrapper
* Fix config page mess caused by very high ordinal placing it above Jenkins core widgets in system configuration
* Merge sections in system configuration to one, it looked very strange with 3
* Convert tables to divs in form layout, note this heavily used tables for layout and I've dropped compatibility with old core to make this easier to implement, understand and maintain.
* Add bom
* Remove workspace requirement for build wrapper (requires somewhat new core (not sure exact version))
* Correct documentation about pipeline being supported for global setting (it's not)
* Implement data-binding for build wrapper, I haven't updated the `configure` method because this plugin uses a super weird pattern where it's describeable object doesn't store the configuration it uses a PoJo then writes directly to the XML file manually. This is a start towards JCasC support if someone wants to implement it

@oleg-nenashev 