### PR TITLE
Prevent error on startup when config is missing

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -479,7 +480,7 @@ public class MaskPasswordsConfig {
         try {
             return (MaskPasswordsConfig) getConfigFile().read();
         }
-        catch(FileNotFoundException e) {
+        catch(FileNotFoundException | NoSuchFileException e) {
             LOGGER.log(Level.WARNING, "No configuration found for Mask Passwords plugin");
         }
         catch(Exception e) {


### PR DESCRIPTION
Otherwise there is an exception on startup. A better fix would be to actually patch the code to do proper file checks, just a quick patch.

```
java.nio.file.NoSuchFileException: ... com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig.xml
        at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:79)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
        at sun.nio.fs.WindowsFileSystemProvider.newByteChannel(WindowsFileSystemProvider.java:230)
        at java.nio.file.Files.newByteChannel(Files.java:361)
        at java.nio.file.Files.newByteChannel(Files.java:407)
        at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384)
        at java.nio.file.Files.newInputStream(Files.java:152)
        at hudson.XmlFile.read(XmlFile.java:148)
        at com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig.load(MaskPasswordsConfig.java:480)
        at com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConfig.getInstance(MaskPasswordsConfig.java:221)
        at com.michelin.cio.hudson.plugins.maskpasswords.MaskPasswordsConsoleLogFilter.decorateLogger(MaskPasswordsConsoleLogFilter.java:60)
        at hudson.model.Run.createBuildListener(Run.java:2003)
        at hudson.model.Run.execute(Run.java:1888)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:97)
        at hudson.model.Executor.run(Executor.java:429)
```

CC @timja @res0nance 