### PR TITLE
Require Jenkins 2.361.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.15</version>
+    <version>4.54</version>
   </parent>
 
   <artifactId>mask-passwords</artifactId>
@@ -15,9 +15,7 @@
   <version>3.2-SNAPSHOT</version>
 
   <properties>
-    <jenkins.version>2.272</jenkins.version>
-    <java.level>8</java.level>
-    <workflow.version>1.8</workflow.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <useBeta>true</useBeta> <!-- CustomDescribableModel -->
   </properties>
 
@@ -71,8 +69,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.263.x</artifactId>
-                <version>20</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1775.vf0577a_a_01778</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer

Updates to the most recent parent pom and updates to require Java 11 and Jenkins 2.361.4 or newer.

https://stats.jenkins.io/pluginversions/mask-passwords.html shows that 60% of the installations of the most recent release of the plugin were already running at least Jenkins 2.361.1 as of the early January 2023 run of that installation count report.  Since a majority of users of the current version are already on Jenkins 2.361.1 or newer, let's modernize the plugin to require Java 11 and Jenkins 2.361.4 or newer.

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends either 2.361.4 or 2.346.3 as minimum required version.  By choosing 2.361.4, the plugin moves from Java 8 to Java 11.

This would be good to combine with #29 for another release of the plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Includes the following pull request to modernize the Jenkinsfile:

* #34 