### PR TITLE
Use https: for scm URL, not git:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/mask-passwords-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/mask-passwords-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/mask-passwords-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/mask-passwords-plugin</url>
     <tag>HEAD</tag>


### PR DESCRIPTION
## Use https: for scm URL, not git:

GitHub has deprecated the unencrypted `git` protocol.  Use the `https` protocol instead.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
