### PR TITLE
[JENKINS-68885] Fix class cast exception when VarMaskRegexEntry data is not bound

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper.java
@@ -108,7 +108,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
         // global regexes
         List<MaskPasswordsConfig.VarMaskRegexEntry> globalVarMaskRegexes = config.getGlobalVarMaskRegexesU();
         for(MaskPasswordsConfig.VarMaskRegexEntry globalVarMaskRegex: globalVarMaskRegexes) {
-            allRegexes.add(globalVarMaskRegex.getValue().getRegex());
+            allRegexes.add(globalVarMaskRegex.getValue());
         }
 
         // job's passwords
@@ -531,7 +531,7 @@ public final class MaskPasswordsBuildWrapper extends SimpleBuildWrapper {
                         continue;
                     }
                     writer.startNode(VAR_MASK_REGEX_NODE);
-                    writer.addAttribute(REGEX_NAME, varMaskRegex.getName());
+                    writer.addAttribute(REGEX_NAME, varMaskRegex.getKey());
                     writer.addAttribute(REGEX_ATT, varMaskRegex.getRegexString());
                     writer.endNode();
                 }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConfig.java
@@ -655,18 +655,18 @@ public class MaskPasswordsConfig {
         }
 
         public String getKey() {
-            return this.getName();
+            return this.key;
         }
 
         public void setKey(String key) {
             this.key = key;
         }
 
-        public VarMaskRegex getValue() {
-            return this.getRegex();
+        public String getValue() {
+            return this.getRegex().getRegex();
         }
-        public void setValue(VarMaskRegex regex) {
-            this.setRegex(regex);
+        public void setValue(String regex) {
+            this.setRegex(new VarMaskRegex(regex));
         }
 
         public String getRegexString() {
@@ -684,7 +684,7 @@ public class MaskPasswordsConfig {
         @SuppressFBWarnings(value = "CN_IDIOM_NO_SUPER_CALL", justification = "We do not expect anybody to use this class."
                 + "If they do, they must override clone() as well")
         public Object clone() {
-            return new VarMaskRegexEntry(this.getName(), this.getRegex());
+            return new VarMaskRegexEntry(this.getKey(), this.getRegex());
         }
 
         @Override
@@ -702,7 +702,7 @@ public class MaskPasswordsConfig {
                 return false;
             } else {
                 VarMaskRegexEntry otherE = (VarMaskRegexEntry) other;
-                return (this.getName().equals(otherE.getName())) && this.getRegex().equals(otherE.getRegex());
+                return (this.getKey().equals(otherE.getKey())) && this.getRegex().equals(otherE.getRegex());
             }
         }
 
@@ -717,7 +717,7 @@ public class MaskPasswordsConfig {
             public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable step) {
                 Map<String, ?> arguments = step.getArguments();
                 Map<String, Object> newMap1 = new HashMap<>();
-                newMap1.put("name", arguments.get("name"));
+                newMap1.put("key", arguments.get("key"));
                 newMap1.put("value", arguments.get("value"));
                 return step.withArguments(newMap1);
             }
@@ -726,8 +726,8 @@ public class MaskPasswordsConfig {
             @Override
             public Map<String, Object> customInstantiate(@NonNull Map<String, Object> arguments) {
                 Map<String, Object> newMap = new HashMap<>();
-                newMap.put("name", arguments.get("name"));
-                newMap.put("value", new VarMaskRegex((String)arguments.get("value")));
+                newMap.put("key", arguments.get("key"));
+                newMap.put("value", String.valueOf(arguments.get("value")));
                 return newMap;
             }
         }

--- a/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsConsoleLogFilter.java
@@ -77,7 +77,7 @@ public class MaskPasswordsConsoleLogFilter extends ConsoleLogFilter  implements 
       // global regexes
       List<MaskPasswordsConfig.VarMaskRegexEntry> globalVarMaskRegexes = config.getGlobalVarMaskRegexesU();
       for(MaskPasswordsConfig.VarMaskRegexEntry globalVarMaskRegex: globalVarMaskRegexes) {
-          regexes.add(globalVarMaskRegex.getValue().getRegex());
+          regexes.add(globalVarMaskRegex.getValue());
       }
       return new MaskPasswordsOutputStream(logger, passwords, regexes);
   }

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -89,7 +89,7 @@ public class MaskPasswordsWorkflowTest {
         story.then(step -> {
                 MaskPasswordsBuildWrapper bw1 = new MaskPasswordsBuildWrapper(
                   null,
-                  Collections.singletonList(new MaskPasswordsConfig.VarMaskRegexEntry("test", new MaskPasswordsBuildWrapper.VarMaskRegex("foobar")))
+                  Collections.singletonList(new MaskPasswordsConfig.VarMaskRegexEntry("test", "foobar"))
                 );
                 CoreWrapperStep step1 = new CoreWrapperStep(bw1);
                 CoreWrapperStep step2 = new StepConfigTester(step).configRoundTrip(step1);
@@ -98,7 +98,7 @@ public class MaskPasswordsWorkflowTest {
                 assertEquals(1, regexes.size());
                 MaskPasswordsConfig.VarMaskRegexEntry regex = regexes.get(0);
                 assertEquals("foobar", regex.getRegexString());
-                assertEquals("test", regex.getName());
+                assertEquals("test", regex.getKey());
         });
     }
 


### PR DESCRIPTION
##  [JENKINS-68885](https://issues.jenkins.io/browse/JENKINS-68885) Fix class cast exception when VarMaskRegexEntry data is not bound

If you try to create a Maskpassword Pipiline using regex, a class cast exception will occur.

DataBoundConstructor uses String and String as parameters, but in Descriptor, it is sent by casting to VarMaskRegex.

If I change the descriptor to properly use VarMaskRegexEntry, it works fine.

### Testing done
Pipeline Script
<img width="1157" alt="image" src="https://github.com/jenkinsci/mask-passwords-plugin/assets/24883918/08169f7d-4b36-4b92-abaf-5cbd0e34fffe">

Console Log Output
<img width="495" alt="image" src="https://github.com/jenkinsci/mask-passwords-plugin/assets/24883918/409315b0-c03c-4a8f-8ab0-a52bbb46025a">



```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
