### PR TITLE
Add workaround for flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -58,6 +58,7 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Issue("JENKINS-27392")
@@ -101,27 +102,23 @@ class MaskPasswordsWorkflowTest {
         p.setDefinition(new CpsFlowDefinition("node {wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'PASSWORD', password: 's3cr3t']]]) {semaphore 'waiting'; echo 'printed s3cr3t oops'}}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
-        Set<String> expected1 = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
+        Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
         if (!Functions.isWindows()) {
             // Skip assertion on Windows, temporary files contaminate content frequently
             await().atMost(5, TimeUnit.SECONDS)
                     .alias("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better")
-                    .until(() ->
-                            expected1.equals(grep(b.getRootDir(), "s3cr3t"))
-                    );
+                    .until(() -> grep(b.getRootDir(), "s3cr3t"), equalTo(expected));
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
-        Set<String> expected2 = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
+        expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
         if (!Functions.isWindows()) {
             // Skip assertion on Windows, temporary files contaminate content frequently
             await().atMost(5, TimeUnit.SECONDS)
                     .alias("in build.xml only because it was literally in program text")
-                    .until(() ->
-                            expected2.equals(grep(b.getRootDir(), "s3cr3t"))
-                    );
+                    .until(() -> grep(b.getRootDir(), "s3cr3t"), equalTo(expected));
         }
     }
 
@@ -131,27 +128,23 @@ class MaskPasswordsWorkflowTest {
         p.setDefinition(new CpsFlowDefinition("node {wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [[key: 'REGEX', value: 's3cr3t']]]) {semaphore 'waiting'; echo 'printed s3cr3t oops'}}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
-        Set<String> expected1 = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
+        Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
         if (!Functions.isWindows()) {
             // Skip assertion on Windows, temporary files contaminate content frequently
             await().atMost(5, TimeUnit.SECONDS)
                     .alias("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better")
-                    .until(() ->
-                            expected1.equals(grep(b.getRootDir(), "s3cr3t"))
-                    );
+                    .until(() -> grep(b.getRootDir(), "s3cr3t"), equalTo(expected));
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
-        Set<String> expected2 = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
+        expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
         if (!Functions.isWindows()) {
             // Skip assertion on Windows, temporary files contaminate content frequently
             await().atMost(5, TimeUnit.SECONDS)
                     .alias("in build.xml only because it was literally in program text")
-                    .until(() ->
-                            expected2.equals(grep(b.getRootDir(), "s3cr3t"))
-                    );
+                    .until(() -> grep(b.getRootDir(), "s3cr3t"), equalTo(expected));
         }
     }
 

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -55,7 +55,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Issue("JENKINS-27392")
@@ -99,22 +101,27 @@ class MaskPasswordsWorkflowTest {
         p.setDefinition(new CpsFlowDefinition("node {wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[var: 'PASSWORD', password: 's3cr3t']]]) {semaphore 'waiting'; echo 'printed s3cr3t oops'}}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
-        Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
-        // Skip assertion on Windows, temporary files contaminate content frequently
+        Set<String> expected1 = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
         if (!Functions.isWindows()) {
-            // Compensate for test being flaky on slow filesystems
-            Set<String> actual = grep(b.getRootDir(), "s3cr3t");
-            actual.removeIf(s -> s.matches("^atomic\\d+\\.tmp$"));
-            assertEquals(expected, actual, "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
+            // Skip assertion on Windows, temporary files contaminate content frequently
+            await().atMost(5, TimeUnit.SECONDS)
+                    .alias("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better")
+                    .until(() ->
+                            expected1.equals(grep(b.getRootDir(), "s3cr3t"))
+                    );
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
-        expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
-        // Skip assertion on Windows, temporary files contaminate content frequently
+        Set<String> expected2 = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
         if (!Functions.isWindows()) {
-            assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "in build.xml only because it was literally in program text");
+            // Skip assertion on Windows, temporary files contaminate content frequently
+            await().atMost(5, TimeUnit.SECONDS)
+                    .alias("in build.xml only because it was literally in program text")
+                    .until(() ->
+                            expected2.equals(grep(b.getRootDir(), "s3cr3t"))
+                    );
         }
     }
 
@@ -124,22 +131,27 @@ class MaskPasswordsWorkflowTest {
         p.setDefinition(new CpsFlowDefinition("node {wrap([$class: 'MaskPasswordsBuildWrapper', varMaskRegexes: [[key: 'REGEX', value: 's3cr3t']]]) {semaphore 'waiting'; echo 'printed s3cr3t oops'}}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
-        Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
-        // Skip assertion on Windows, temporary files contaminate content frequently
+        Set<String> expected1 = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
         if (!Functions.isWindows()) {
-            // Compensate for test being flaky on slow filesystems
-            Set<String> actual = grep(b.getRootDir(), "s3cr3t");
-            actual.removeIf(s -> s.matches("^atomic\\d+\\.tmp$"));
-            assertEquals(expected, actual, "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
+            // Skip assertion on Windows, temporary files contaminate content frequently
+            await().atMost(5, TimeUnit.SECONDS)
+                    .alias("TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better")
+                    .until(() ->
+                            expected1.equals(grep(b.getRootDir(), "s3cr3t"))
+                    );
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
-        expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
-        // Skip assertion on Windows, temporary files contaminate content frequently
+        Set<String> expected2 = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
         if (!Functions.isWindows()) {
-            assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "in build.xml only because it was literally in program text");
+            // Skip assertion on Windows, temporary files contaminate content frequently
+            await().atMost(5, TimeUnit.SECONDS)
+                    .alias("in build.xml only because it was literally in program text")
+                    .until(() ->
+                            expected2.equals(grep(b.getRootDir(), "s3cr3t"))
+                    );
         }
     }
 

--- a/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
+++ b/src/test/java/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsWorkflowTest.java
@@ -100,17 +100,20 @@ class MaskPasswordsWorkflowTest {
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
         Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
+        // Skip assertion on Windows, temporary files contaminate content frequently
         if (!Functions.isWindows()) {
-            // Skip assertion on Windows, temporary files contaminate content frequently
-            assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
+            // Compensate for test being flaky on slow filesystems
+            Set<String> actual = grep(b.getRootDir(), "s3cr3t");
+            actual.removeIf(s -> s.matches("^atomic\\d+\\.tmp$"));
+            assertEquals(expected, actual, "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
         expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
+        // Skip assertion on Windows, temporary files contaminate content frequently
         if (!Functions.isWindows()) {
-            // Skip assertion on Windows, temporary files contaminate content frequently
             assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "in build.xml only because it was literally in program text");
         }
     }
@@ -122,17 +125,20 @@ class MaskPasswordsWorkflowTest {
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("waiting/1", b);
         Set<String> expected = new HashSet<>(Arrays.asList("build.xml", "program.dat", "workflow/5.xml"));
+        // Skip assertion on Windows, temporary files contaminate content frequently
         if (!Functions.isWindows()) {
-            // Skip assertion on Windows, temporary files contaminate content frequently
-            assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
+            // Compensate for test being flaky on slow filesystems
+            Set<String> actual = grep(b.getRootDir(), "s3cr3t");
+            actual.removeIf(s -> s.matches("^atomic\\d+\\.tmp$"));
+            assertEquals(expected, actual, "TODO cannot keep it out of the closure block, but at least outside users cannot see this; withCredentials does better");
         }
         SemaphoreStep.success("waiting/1", null);
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("printed ******** oops", b);
         j.assertLogNotContains("printed s3cr3t oops", b);
         expected = new HashSet<>(Arrays.asList("build.xml", "workflow-completed/flowNodeStore.xml"));
+        // Skip assertion on Windows, temporary files contaminate content frequently
         if (!Functions.isWindows()) {
-            // Skip assertion on Windows, temporary files contaminate content frequently
             assertEquals(expected, grep(b.getRootDir(), "s3cr3t"), "in build.xml only because it was literally in program text");
         }
     }


### PR DESCRIPTION
See https://github.com/jenkinsci/bom/pull/5046 for context.

It seems like `MaskPasswordsWorkflowTest#basics` and `MaskPasswordsWorkflowTest#basicsRegex` are being flaky on slow filesystems. 
If accepted, this change must be released in order to resolve https://github.com/jenkinsci/bom/issues/4781

### Testing done

Since I cannot reproduce the error _naturally_ I manually added a `atomic12345.tmp` file containing `s3cr3t` to check if the workaround behaves as intented.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed