### PR TITLE
Use jenkins-alert-warning instead of a hard coded color

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/maskpasswords/MaskPasswordsBuildWrapper/config.jelly
@@ -24,7 +24,7 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <div class="help" style="display:block;background-color:#F7F1DA;">
+    <div class="jenkins-alert jenkins-alert-warning">
         ${%HowToConfigureThisPlugin}
     </div>
     <f:entry title="${%PasswordPairTitle}">


### PR DESCRIPTION
The hard coded color make it impossible to read the text with dark theme
<!-- Please describe your pull request here. -->

Before:
![image](https://github.com/user-attachments/assets/6d94ba76-67c4-4d42-aabd-f00f6f8912ef)

After:
![image](https://github.com/user-attachments/assets/c5af844c-355b-49f8-9a51-42167c72366c)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
