### PR TITLE
Declare dependencies and ban JUnit 4 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.22</version>
     <relativePath />
   </parent>
 
@@ -16,12 +16,14 @@
   <version>${changelist}</version>
 
   <properties>
+    <hpi.bundledArtifacts />
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/mask-passwords-plugin</gitHubRepo>
-    <useBeta>true</useBeta> <!-- CustomDescribableModel -->
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <scm>


### PR DESCRIPTION
## Declare dependencies and ban JUnit 4 tests

Declare dependencies explicitly so that dependency updates do not inadvertently bundle a new dependency in the plugin.

Ban JUnit 4 tests because the tests in the plugin have all been converted to JUnit 5.

### Testing done

Confirmed that the plugin compiles and passes automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
